### PR TITLE
Create debug builds without the need of keystore file

### DIFF
--- a/dicekey/build.gradle
+++ b/dicekey/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jetbrains.dokka'
 
+//https://developer.android.com/studio/publish/app-signing#secure-key
 // Create a variable called keystorePropertiesFile, and initialize it to your
 // keystore.properties file, in the rootProject folder.
 def keystorePropertiesFile = rootProject.file("keystore.properties")
@@ -12,7 +13,9 @@ def keystorePropertiesFile = rootProject.file("keystore.properties")
 def keystoreProperties = new Properties()
 
 // Load your keystore.properties file into the keystoreProperties object.
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+if (keystorePropertiesFile.exists()){
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
 
 android {
     ndkVersion '21.0.6113669'
@@ -22,16 +25,10 @@ android {
 
     signingConfigs {
         release {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
-        }
-        debug {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
+            storeFile keystoreProperties.containsKey("storeFile") ? file(keystoreProperties['storeFile']) : null
+            storePassword keystoreProperties.containsKey("storePassword") ? keystoreProperties['storePassword'] : ""
+            keyAlias keystoreProperties.containsKey("keyAlias") ? keystoreProperties['keyAlias'] : ""
+            keyPassword keystoreProperties.containsKey("keyPassword") ? keystoreProperties['keyPassword'] : ""
         }
     }
 
@@ -57,7 +54,6 @@ android {
                 debuggable true
                 initWith debug
                 jniDebuggable true
-                signingConfig signingConfigs.debug
             }
         }
     }

--- a/fidowriter/build.gradle
+++ b/fidowriter/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
+//https://developer.android.com/studio/publish/app-signing#secure-key
 // Create a variable called keystorePropertiesFile, and initialize it to your
 // keystore.properties file, in the rootProject folder.
 def keystorePropertiesFile = rootProject.file("keystore.properties")
@@ -10,7 +11,9 @@ def keystorePropertiesFile = rootProject.file("keystore.properties")
 def keystoreProperties = new Properties()
 
 // Load your keystore.properties file into the keystoreProperties object.
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+if (keystorePropertiesFile.exists()){
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
 
 android {
     compileSdkVersion 29
@@ -18,16 +21,10 @@ android {
 
     signingConfigs {
         release {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
-        }
-        debug {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
+            storeFile keystoreProperties.containsKey("storeFile") ? file(keystoreProperties['storeFile']) : null
+            storePassword keystoreProperties.containsKey("storePassword") ? keystoreProperties['storePassword'] : ""
+            keyAlias keystoreProperties.containsKey("keyAlias") ? keystoreProperties['keyAlias'] : ""
+            keyPassword keystoreProperties.containsKey("keyPassword") ? keystoreProperties['keyPassword'] : ""
         }
     }
     buildTypes {
@@ -40,7 +37,6 @@ android {
             debuggable true
             initWith debug
             jniDebuggable true
-            signingConfig signingConfigs.debug
         }
     }
 

--- a/keystore.properties.template
+++ b/keystore.properties.template
@@ -1,0 +1,7 @@
+# This file is in .gitignore, so changes are not going to be commited
+
+storeFile=release-keystore.jks
+storePassword=STORE_PASSWORD
+keyAlias=KEY_ALIAS
+keyPassword=KEY_PASSWORD
+

--- a/read/build.gradle
+++ b/read/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jetbrains.dokka'
 
+//https://developer.android.com/studio/publish/app-signing#secure-key
 // Create a variable called keystorePropertiesFile, and initialize it to your
 // keystore.properties file, in the rootProject folder.
 def keystorePropertiesFile = rootProject.file("keystore.properties")
@@ -12,7 +13,9 @@ def keystorePropertiesFile = rootProject.file("keystore.properties")
 def keystoreProperties = new Properties()
 
 // Load your keystore.properties file into the keystoreProperties object.
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+if (keystorePropertiesFile.exists()){
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
 
 android {
     ndkVersion '21.0.6113669'
@@ -22,16 +25,10 @@ android {
 
     signingConfigs {
         release {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
-        }
-        debug {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
+            storeFile keystoreProperties.containsKey("storeFile") ? file(keystoreProperties['storeFile']) : null
+            storePassword keystoreProperties.containsKey("storePassword") ? keystoreProperties['storePassword'] : ""
+            keyAlias keystoreProperties.containsKey("keyAlias") ? keystoreProperties['keyAlias'] : ""
+            keyPassword keystoreProperties.containsKey("keyPassword") ? keystoreProperties['keyPassword'] : ""
         }
     }
 
@@ -54,7 +51,6 @@ android {
                 debuggable true
                 initWith debug
                 jniDebuggable true
-                signingConfig signingConfigs.debug
             }
         }
 

--- a/seeded/build.gradle
+++ b/seeded/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jetbrains.dokka'
 
+//https://developer.android.com/studio/publish/app-signing#secure-key
 // Create a variable called keystorePropertiesFile, and initialize it to your
 // keystore.properties file, in the rootProject folder.
 def keystorePropertiesFile = rootProject.file("keystore.properties")
@@ -12,7 +13,9 @@ def keystorePropertiesFile = rootProject.file("keystore.properties")
 def keystoreProperties = new Properties()
 
 // Load your keystore.properties file into the keystoreProperties object.
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+if (keystorePropertiesFile.exists()){
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
 
 
 android {
@@ -23,16 +26,10 @@ android {
 
     signingConfigs {
         release {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
-        }
-        debug {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
+            storeFile keystoreProperties.containsKey("storeFile") ? file(keystoreProperties['storeFile']) : null
+            storePassword keystoreProperties.containsKey("storePassword") ? keystoreProperties['storePassword'] : ""
+            keyAlias keystoreProperties.containsKey("keyAlias") ? keystoreProperties['keyAlias'] : ""
+            keyPassword keystoreProperties.containsKey("keyPassword") ? keystoreProperties['keyPassword'] : ""
         }
 
     }
@@ -65,7 +62,6 @@ android {
             debuggable true
             initWith debug
             jniDebuggable false
-            signingConfig signingConfigs.debug
         }
     }
 

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
+//https://developer.android.com/studio/publish/app-signing#secure-key
 // Create a variable called keystorePropertiesFile, and initialize it to your
 // keystore.properties file, in the rootProject folder.
 def keystorePropertiesFile = rootProject.file("keystore.properties")
@@ -10,22 +11,18 @@ def keystorePropertiesFile = rootProject.file("keystore.properties")
 def keystoreProperties = new Properties()
 
 // Load your keystore.properties file into the keystoreProperties object.
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+if (keystorePropertiesFile.exists()){
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
 
 //  from android{      signingConfig signingConfigs.release
 android {
     signingConfigs {
         release {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
-        }
-        debug {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
+            storeFile keystoreProperties.containsKey("storeFile") ? file(keystoreProperties['storeFile']) : null
+            storePassword keystoreProperties.containsKey("storePassword") ? keystoreProperties['storePassword'] : ""
+            keyAlias keystoreProperties.containsKey("keyAlias") ? keystoreProperties['keyAlias'] : ""
+            keyPassword keystoreProperties.containsKey("keyPassword") ? keystoreProperties['keyPassword'] : ""
         }
     }
 
@@ -39,7 +36,6 @@ android {
             debuggable true
             initWith debug
             jniDebuggable true
-            signingConfig signingConfigs.debug
         }
     }
 

--- a/trustedapp/build.gradle
+++ b/trustedapp/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'org.jetbrains.dokka'
 
+//https://developer.android.com/studio/publish/app-signing#secure-key
 // Create a variable called keystorePropertiesFile, and initialize it to your
 // keystore.properties file, in the rootProject folder.
 def keystorePropertiesFile = rootProject.file("keystore.properties")
@@ -11,7 +12,9 @@ def keystorePropertiesFile = rootProject.file("keystore.properties")
 def keystoreProperties = new Properties()
 
 // Load your keystore.properties file into the keystoreProperties object.
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+if (keystorePropertiesFile.exists()){
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
 
 android {
     ndkVersion '21.0.6113669'
@@ -21,16 +24,10 @@ android {
 
     signingConfigs {
         release {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
-        }
-        debug {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
+            storeFile keystoreProperties.containsKey("storeFile") ? file(keystoreProperties['storeFile']) : null
+            storePassword keystoreProperties.containsKey("storePassword") ? keystoreProperties['storePassword'] : ""
+            keyAlias keystoreProperties.containsKey("keyAlias") ? keystoreProperties['keyAlias'] : ""
+            keyPassword keystoreProperties.containsKey("keyPassword") ? keystoreProperties['keyPassword'] : ""
         }
     }
 
@@ -49,11 +46,11 @@ android {
                 proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
                 signingConfig signingConfigs.release
             }
+
             debug {
                 debuggable true
                 initWith debug
                 jniDebuggable true
-                signingConfig signingConfigs.debug
             }
         }
 


### PR DESCRIPTION
Make the presense of keystore and keystore properties file optional.
You can make debug builds without signing the apks for the device/emulator.

It's a fix for #35