### PR TITLE
add ndk version to app gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    ndkVersion '21.1.6352462'
 }
 
 // Enable transforming @AndroidEntryPoint classes in local jvm tests


### PR DESCRIPTION
When I tried to run the new app module, Android didn't treat it as a module.

Upon some stackoverflowing around, I read that gradle wouldn't recognize it as a module without an ndkVersion.  So, I added one.

I'm not sure if this is the right thing to do as I worry it may cause a problem if others don't have the same ndk build.