### PR TITLE
Use Recipe in place of DerivationOptions within SeededCrypto

### DIFF
--- a/api/src/main/java/org/dicekeys/api/Api.kt
+++ b/api/src/main/java/org/dicekeys/api/Api.kt
@@ -188,7 +188,7 @@ abstract class Api(
       packagedSealedMessage: PackagedSealedMessage
     ): ByteArray =
       unsealWithUnsealingKeyMarshaller.call(
-        authTokenIfRequired(ApiDerivationOptions(packagedSealedMessage.derivationOptionsJson)) ?:
+        authTokenIfRequired(ApiDerivationOptions(packagedSealedMessage.recipe)) ?:
         authTokenIfRequired(UnsealingInstructions(packagedSealedMessage.unsealingInstructions))
       ) {
         marshallParameter(Inputs.unsealWithUnsealingKey.packagedSealedMessageJson, packagedSealedMessage)
@@ -240,7 +240,7 @@ abstract class Api(
       packagedSealedMessage: PackagedSealedMessage
     ): ByteArray =
       unsealWithSymmetricKeyMarshaller.call(
-        authTokenIfRequired(ApiDerivationOptions(packagedSealedMessage.derivationOptionsJson)) ?:
+        authTokenIfRequired(ApiDerivationOptions(packagedSealedMessage.recipe)) ?:
         authTokenIfRequired(UnsealingInstructions(packagedSealedMessage.unsealingInstructions))
       ) {
         marshallParameter(Inputs.unsealWithSymmetricKey.packagedSealedMessageJson, packagedSealedMessage)

--- a/seeded/src/main/cpp/java-throw-exception.cpp
+++ b/seeded/src/main/cpp/java-throw-exception.cpp
@@ -41,10 +41,10 @@ void throwCppExceptionAsJavaException(
     javaThrow(env, "org/dicekeys/crypto/seeded/JsonParsingException", e.what());
     return;
 
-  } catch (InvalidDerivationOptionsJsonException e) {
+  } catch (InvalidRecipeJsonException e) {
     javaThrow(env, "org/dicekeys/crypto/seeded/InvalidDerivationOptionsJsonException", e.what());
     return;
-  } catch (InvalidDerivationOptionValueException e) {
+  } catch (InvalidRecipeValueException e) {
     javaThrow(env, "org/dicekeys/crypto/seeded/InvalidDerivationOptionValueException", e.what());
     return;
   } catch (KeyLengthException e) {

--- a/seeded/src/main/cpp/packaged-sealed-message-jni.cpp
+++ b/seeded/src/main/cpp/packaged-sealed-message-jni.cpp
@@ -23,13 +23,13 @@ Java_org_dicekeys_crypto_seeded_PackagedSealedMessage_unsealingInstructionsGette
 }
 
 JNIEXPORT jstring JNICALL
-Java_org_dicekeys_crypto_seeded_PackagedSealedMessage_derivationOptionsJsonGetterJNI(
+Java_org_dicekeys_crypto_seeded_PackagedSealedMessage_recipeGetterJNI(
   JNIEnv *env,
   jobject thiz
 ) {
   try {
     return stringToJString(env,
-      getNativeObjectPtr<PackagedSealedMessage>(env, thiz)->derivationOptionsJson
+      getNativeObjectPtr<PackagedSealedMessage>(env, thiz)->recipe
     );
   } catch (...) {
     throwCppExceptionAsJavaException(env, std::current_exception());

--- a/seeded/src/main/cpp/password-jni.cpp
+++ b/seeded/src/main/cpp/password-jni.cpp
@@ -24,13 +24,13 @@ Java_org_dicekeys_crypto_seeded_Password_toJson(
 }
 
 JNIEXPORT jstring JNICALL
-Java_org_dicekeys_crypto_seeded_Password_derivationOptionsJsonGetterJNI(
+Java_org_dicekeys_crypto_seeded_Password_recipeGetterJNI(
   JNIEnv *env,
   jobject thiz
 ) {
   try {
     return stringToJString(env,
-      getNativeObjectPtr<Password>(env, thiz)->derivationOptionsJson
+      getNativeObjectPtr<Password>(env, thiz)->recipe
     );
   } catch (...) {
     throwCppExceptionAsJavaException(env, std::current_exception());

--- a/seeded/src/main/cpp/sealing-key-jni.cpp
+++ b/seeded/src/main/cpp/sealing-key-jni.cpp
@@ -72,13 +72,13 @@ JNIEXPORT jbyteArray JNICALL Java_org_dicekeys_crypto_seeded_SealingKey_keyBytes
   }
 }
 
-JNIEXPORT jstring JNICALL Java_org_dicekeys_crypto_seeded_SealingKey_derivationOptionsJsonGetterJNI(
+JNIEXPORT jstring JNICALL Java_org_dicekeys_crypto_seeded_SealingKey_recipeGetterJNI(
     JNIEnv* env,
     jobject obj
 ) {
   try {
     return stringToJString(env,
-      getNativeObjectPtr<SealingKey>(env, obj)->getDerivationOptionsJson()
+      getNativeObjectPtr<SealingKey>(env, obj)->getRecipeJson()
     );
   } catch (...) {
     throwCppExceptionAsJavaException(env, std::current_exception());

--- a/seeded/src/main/cpp/secret-jni.cpp
+++ b/seeded/src/main/cpp/secret-jni.cpp
@@ -24,13 +24,13 @@ Java_org_dicekeys_crypto_seeded_Secret_toJson(
 }
 
 JNIEXPORT jstring JNICALL
-Java_org_dicekeys_crypto_seeded_Secret_derivationOptionsJsonGetterJNI(
+Java_org_dicekeys_crypto_seeded_Secret_recipeGetterJNI(
   JNIEnv *env,
   jobject thiz
 ) {
   try {
     return stringToJString(env,
-      getNativeObjectPtr<Secret>(env, thiz)->derivationOptionsJson
+      getNativeObjectPtr<Secret>(env, thiz)->recipe
     );
   } catch (...) {
     throwCppExceptionAsJavaException(env, std::current_exception());

--- a/seeded/src/main/cpp/signature-verification-key-jni.cpp
+++ b/seeded/src/main/cpp/signature-verification-key-jni.cpp
@@ -71,14 +71,14 @@ Java_org_dicekeys_crypto_seeded_SignatureVerificationKey_keyBytesGetterJNI(
 }
 
 JNIEXPORT jstring JNICALL
-Java_org_dicekeys_crypto_seeded_SignatureVerificationKey_derivationOptionsJsonGetterJNI(
+Java_org_dicekeys_crypto_seeded_SignatureVerificationKey_recipeGetterJNI(
   JNIEnv *env,
   jobject obj
 ) {
   try {
     return stringToJString(env,
                            getNativeObjectPtr<SignatureVerificationKey>(env,
-                                                                        obj)->getDerivationOptionsJson()
+                                                                        obj)->getRecipeJson()
     );
   } catch (...) {
     throwCppExceptionAsJavaException(env, std::current_exception());

--- a/seeded/src/main/cpp/signing-key-jni.cpp
+++ b/seeded/src/main/cpp/signing-key-jni.cpp
@@ -45,13 +45,13 @@ Java_org_dicekeys_crypto_seeded_SigningKey_generateSignature(
 }
 
 JNIEXPORT jstring JNICALL
-Java_org_dicekeys_crypto_seeded_SigningKey_derivationOptionsJsonGetterJNI(
+Java_org_dicekeys_crypto_seeded_SigningKey_recipeGetterJNI(
   JNIEnv *env,
     jobject thiz
   ) {
   try {
     return stringToJString(env,
-      getNativeObjectPtr<SigningKey>(env, thiz)->derivationOptionsJson
+      getNativeObjectPtr<SigningKey>(env, thiz)->recipe
     );
   } catch (...) {
     throwCppExceptionAsJavaException(env, std::current_exception());

--- a/seeded/src/main/cpp/symmetric-key-jni.cpp
+++ b/seeded/src/main/cpp/symmetric-key-jni.cpp
@@ -85,13 +85,13 @@ Java_org_dicekeys_crypto_seeded_SymmetricKey_toJson(
 }
 
 JNIEXPORT jstring JNICALL
-Java_org_dicekeys_crypto_seeded_SymmetricKey_derivationOptionsJsonGetterJNI(
+Java_org_dicekeys_crypto_seeded_SymmetricKey_recipeGetterJNI(
     JNIEnv *env,
     jobject thiz
 ) {
   try {
     return stringToJString(env,
-      getNativeObjectPtr<SymmetricKey>(env, thiz)->derivationOptionsJson
+      getNativeObjectPtr<SymmetricKey>(env, thiz)->recipe
     );
   } catch (...) {
     throwCppExceptionAsJavaException(env, std::current_exception());

--- a/seeded/src/main/cpp/unsealing-key-jni.cpp
+++ b/seeded/src/main/cpp/unsealing-key-jni.cpp
@@ -41,13 +41,13 @@ Java_org_dicekeys_crypto_seeded_UnsealingKey_toJson(
 }
 
 JNIEXPORT jstring JNICALL
-Java_org_dicekeys_crypto_seeded_UnsealingKey_derivationOptionsJsonGetterJNI(
+Java_org_dicekeys_crypto_seeded_UnsealingKey_recipeGetterJNI(
   JNIEnv *env,
   jobject thiz
 ) {
   try {
     return stringToJString(env,
-      getNativeObjectPtr<UnsealingKey>(env, thiz)->derivationOptionsJson
+      getNativeObjectPtr<UnsealingKey>(env, thiz)->recipe
     );
   } catch (...) {
     throwCppExceptionAsJavaException(env, std::current_exception());
@@ -105,7 +105,7 @@ Java_org_dicekeys_crypto_seeded_UnsealingKey_getSealingKeyPtrJNI(
       getNativeObjectPtr<UnsealingKey>(env, thiz);
     return (jlong) new SealingKey(
       UnsealingKeyPtr->sealingKeyBytes,
-      UnsealingKeyPtr->derivationOptionsJson
+      UnsealingKeyPtr->recipe
     );
   } catch (...) {
     throwCppExceptionAsJavaException(env, std::current_exception());

--- a/seeded/src/main/java/org/dicekeys/crypto/seeded/PackagedSealedMessage.kt
+++ b/seeded/src/main/java/org/dicekeys/crypto/seeded/PackagedSealedMessage.kt
@@ -20,7 +20,7 @@ class PackagedSealedMessage internal constructor(
 
         @JvmStatic private external fun constructJNI(
             ciphertext: ByteArray,
-            derivationOptionsJson: String,
+            recipe: String,
             unsealingInstructions: String
         ) : Long
 
@@ -69,7 +69,7 @@ class PackagedSealedMessage internal constructor(
     private external fun deleteNativeObjectPtrJNI()
 
     private external fun ciphertextGetterJNI(): ByteArray
-    private external fun derivationOptionsJsonGetterJNI(): String
+    private external fun recipeGetterJNI(): String
     private external fun unsealingInstructionsGetterJNI(): String
 
     /**
@@ -80,7 +80,7 @@ class PackagedSealedMessage internal constructor(
     /**
      * The options that guided the derivation of the key used to seal/unseal the message.
      */
-    val derivationOptionsJson: String get() = derivationOptionsJsonGetterJNI()
+    val recipe: String get() = recipeGetterJNI()
 
     /**
      * An optional string that provides instructions the party unsealing the message should
@@ -95,16 +95,16 @@ class PackagedSealedMessage internal constructor(
      */
     constructor(
         other: PackagedSealedMessage
-    ) : this(other.ciphertext, other.derivationOptionsJson, other.unsealingInstructions)
+    ) : this(other.ciphertext, other.recipe, other.unsealingInstructions)
 
     /**
      * Construct this object from its member values
      */
     constructor(
             ciphertext: ByteArray,
-            derivationOptionsJson: String,
+            recipe: String,
             unsealingInstructions: String
-    ) : this( constructJNI(ciphertext, derivationOptionsJson, unsealingInstructions) )
+    ) : this( constructJNI(ciphertext, recipe, unsealingInstructions) )
 
     protected fun finalize() {
         deleteNativeObjectPtrJNI()

--- a/seeded/src/main/java/org/dicekeys/crypto/seeded/Password.kt
+++ b/seeded/src/main/java/org/dicekeys/crypto/seeded/Password.kt
@@ -8,7 +8,7 @@ package org.dicekeys.crypto.seeded
  * Because secret derivation uses a one-way function, this secret can be shared without
  * revealing the secret seed used to derive it.
  * It can then be used and, if lost, re-derived from the original seed and
- * [derivationOptionsJson] that were first used to derive it.
+ * [recipe] that were first used to derive it.
  *
  * This class wraps the native c++ Secret class from the
  * DiceKeys [Seeded Cryptography Library](https://dicekeys.github.io/seeded-crypto/).
@@ -24,12 +24,12 @@ class Password private constructor(
 
         @JvmStatic private external fun constructJNI(
                 password: String,
-                derivationOptionsJson: String
+                recipe: String
         ) : Long
 
         @JvmStatic private external fun deriveFromSeedJNI(
                 seedString: String,
-                derivationOptionsJson: String,
+                recipe: String,
                 wordListAsSingleString: String = ""
         ) : Long
 
@@ -42,9 +42,9 @@ class Password private constructor(
         @JvmStatic
         fun deriveFromSeed(
                 seedString: String,
-                derivationOptionsJson: String,
+                recipe: String,
                 wordListAsSingleString: String = ""
-        ) = Password(deriveFromSeedJNI(seedString, derivationOptionsJson, wordListAsSingleString))
+        ) = Password(deriveFromSeedJNI(seedString, recipe, wordListAsSingleString))
 
 
         @JvmStatic private external fun fromJsonJNI(
@@ -84,11 +84,11 @@ class Password private constructor(
 
     private external fun deleteNativeObjectPtrJNI()
     private external fun passwordGetterJNI(): String
-    private external fun derivationOptionsJsonGetterJNI(): String
+    private external fun recipeGetterJNI(): String
 
     /**
      * Serialize the object to a JSON format that stores both the [password]
-     * and the [derivationOptionsJson] used to generate it.
+     * and the [recipe] used to generate it.
      * (The secret seed string used to generate it is not stored, as it is
      * not kept after the object is constructed.)
      */
@@ -103,7 +103,7 @@ class Password private constructor(
      * The options that guided the derivation of this key from the raw seed that was
      * passed to [fromJson].
      */
-    val derivationOptionsJson: String get() = derivationOptionsJsonGetterJNI()
+    val recipe: String get() = recipeGetterJNI()
 
     /**
      * A copy constructor to prevent copying of the native pointer, which would lead
@@ -111,15 +111,15 @@ class Password private constructor(
      */
     constructor(
             other: Password
-    ) : this(other.password, other.derivationOptionsJson)
+    ) : this(other.password, other.recipe)
 
     /**
      * Construct this object from its member values
      */
     internal constructor(
             password: String,
-            derivationOptionsJson: String
-    ) : this( constructJNI(password, derivationOptionsJson) )
+            recipe: String
+    ) : this( constructJNI(password, recipe) )
 
     protected fun finalize() {
         deleteNativeObjectPtrJNI()

--- a/seeded/src/main/java/org/dicekeys/crypto/seeded/SealingKey.kt
+++ b/seeded/src/main/java/org/dicekeys/crypto/seeded/SealingKey.kt
@@ -56,7 +56,7 @@ class SealingKey internal constructor(
 
         @JvmStatic private external fun constructJNI(
                 keyBytes: ByteArray,
-                derivationOptionsJson: String = ""
+                recipe: String = ""
         ) : Long
 
         @JvmStatic private external fun fromSerializedBinaryFormJNI(
@@ -85,17 +85,17 @@ class SealingKey internal constructor(
      */
     constructor(
         other: SealingKey
-    ) : this(other.keyBytes, other.derivationOptionsJson)
+    ) : this(other.keyBytes, other.recipe)
 
     /**
      * Construct by specifying the value of each member
      */
     internal constructor(
             keyBytes: ByteArray,
-            derivationOptionsJson: String
+            recipe: String
     ) : this ( constructJNI(
             keyBytes,
-            derivationOptionsJson
+            recipe
     ) )
 
     protected fun finalize() {
@@ -103,7 +103,7 @@ class SealingKey internal constructor(
     }
     private external fun deleteNativeObjectPtrJNI()
     private external fun keyBytesGetterJNI(): ByteArray
-    private external fun derivationOptionsJsonGetterJNI(): String
+    private external fun recipeGetterJNI(): String
 
     /**
      * Serialize the object to JSON format so that it can later be
@@ -124,7 +124,7 @@ class SealingKey internal constructor(
      * The key-derivation options used to derive the [SealingKey] and its corresponding
      * [UnsealingKey]
      */
-    val derivationOptionsJson get() = derivationOptionsJsonGetterJNI()
+    val recipe get() = recipeGetterJNI()
 
     /**
      * Seal a plaintext message to create a ciphertext which can only be unsealed
@@ -167,7 +167,7 @@ class SealingKey internal constructor(
 
     override fun equals(other: Any?): Boolean =
             (other is SealingKey) &&
-            derivationOptionsJson == other.derivationOptionsJson &&
+            recipe == other.recipe &&
             keyBytes.contentEquals(other.keyBytes)
 
     /**

--- a/seeded/src/main/java/org/dicekeys/crypto/seeded/Secret.kt
+++ b/seeded/src/main/java/org/dicekeys/crypto/seeded/Secret.kt
@@ -8,7 +8,7 @@ package org.dicekeys.crypto.seeded
  * Because secret derivation uses a one-way function, this secret can be shared without
  * revealing the secret seed used to derive it.
  * It can then be used and, if lost, re-derived from the original seed and
- * [derivationOptionsJson] that were first used to derive it.
+ * [recipe] that were first used to derive it.
  *
  * This class wraps the native c++ Secret class from the
  * DiceKeys [Seeded Cryptography Library](https://dicekeys.github.io/seeded-crypto/).
@@ -24,12 +24,12 @@ class Secret private constructor(
 
         @JvmStatic private external fun constructJNI(
                 seedBytes: ByteArray,
-                derivationOptionsJson: String
+                recipe: String
         ) : Long
 
         @JvmStatic private external fun deriveFromSeedJNI(
                 seedString: String,
-                derivationOptionsJson: String
+                recipe: String
         ) : Long
 
         /**
@@ -39,8 +39,8 @@ class Secret private constructor(
         @JvmStatic
         fun deriveFromSeed(
                 seedString: String,
-                derivationOptionsJson: String
-        ) = Secret(deriveFromSeedJNI(seedString, derivationOptionsJson))
+                recipe: String
+        ) = Secret(deriveFromSeedJNI(seedString, recipe))
 
 
         @JvmStatic private external fun fromJsonJNI(
@@ -80,11 +80,11 @@ class Secret private constructor(
 
     private external fun deleteNativeObjectPtrJNI()
     private external fun secretBytesGetterJNI(): ByteArray
-    private external fun derivationOptionsJsonGetterJNI(): String
+    private external fun recipeGetterJNI(): String
 
     /**
      * Serialize the object to a JSON format that stores both the [secretBytes]
-     * and the [derivationOptionsJson] used to generate it.
+     * and the [recipe] used to generate it.
      * (The secret seed string used to generate it is not stored, as it is
      * not kept after the object is constructed.)
      */
@@ -105,7 +105,7 @@ class Secret private constructor(
      * The options that guided the derivation of this key from the raw seed that was
      * passed to [fromJson].
      */
-    val derivationOptionsJson: String get() = derivationOptionsJsonGetterJNI()
+    val recipe: String get() = recipeGetterJNI()
 
     /**
      * A copy constructor to prevent copying of the native pointer, which would lead
@@ -113,15 +113,15 @@ class Secret private constructor(
      */
     constructor(
             other: Secret
-    ) : this(other.secretBytes, other.derivationOptionsJson)
+    ) : this(other.secretBytes, other.recipe)
 
     /**
      * Construct this object from its member values
      */
     internal constructor(
             secretBytes: ByteArray,
-            derivationOptionsJson: String
-    ) : this( constructJNI(secretBytes, derivationOptionsJson) )
+            recipe: String
+    ) : this( constructJNI(secretBytes, recipe) )
 
     protected fun finalize() {
         deleteNativeObjectPtrJNI()

--- a/seeded/src/main/java/org/dicekeys/crypto/seeded/SignatureVerificationKey.kt
+++ b/seeded/src/main/java/org/dicekeys/crypto/seeded/SignatureVerificationKey.kt
@@ -41,7 +41,7 @@ import org.dicekeys.crypto.seeded.utilities.qrCodeNativeSizeInQrCodeSquarePixels
 
         @JvmStatic private external fun constructJNI(
                 keyBytes: ByteArray,
-                derivationOptionsJson: String
+                recipe: String
         ) : Long
 
        @JvmStatic private external fun fromSerializedBinaryFormJNI(
@@ -71,7 +71,7 @@ import org.dicekeys.crypto.seeded.utilities.qrCodeNativeSizeInQrCodeSquarePixels
      */
     constructor(
             other: SealingKey
-    ) : this(other.keyBytes, other.derivationOptionsJson)
+    ) : this(other.keyBytes, other.recipe)
 
 
     /**
@@ -79,10 +79,10 @@ import org.dicekeys.crypto.seeded.utilities.qrCodeNativeSizeInQrCodeSquarePixels
      */
     constructor(
             keyBytes: ByteArray,
-            derivationOptionsJson: String = ""
+            recipe: String = ""
     ) : this ( constructJNI(
             keyBytes,
-            derivationOptionsJson
+            recipe
     ) )
 
     protected fun finalize() {
@@ -90,7 +90,7 @@ import org.dicekeys.crypto.seeded.utilities.qrCodeNativeSizeInQrCodeSquarePixels
     }
     private external fun deleteNativeObjectPtrJNI()
     private external fun keyBytesGetterJNI(): ByteArray
-    private external fun derivationOptionsJsonGetterJNI(): String
+    private external fun recipeGetterJNI(): String
 
     /**
      * Serialize the object to JSON format so that it can later be
@@ -111,11 +111,11 @@ import org.dicekeys.crypto.seeded.utilities.qrCodeNativeSizeInQrCodeSquarePixels
      * The key-derivation options used to derive this [SigningKey] and its corresponding
      * [SignatureVerificationKey]
      */
-    val derivationOptionsJson get() = derivationOptionsJsonGetterJNI()
+    val recipe get() = recipeGetterJNI()
 
     override fun equals(other: Any?): Boolean =
         (other is SignatureVerificationKey) &&
-        derivationOptionsJson == other.derivationOptionsJson &&
+        recipe == other.recipe &&
         keyBytes.contentEquals(other.keyBytes)
 
     /**

--- a/seeded/src/main/java/org/dicekeys/crypto/seeded/SigningKey.kt
+++ b/seeded/src/main/java/org/dicekeys/crypto/seeded/SigningKey.kt
@@ -10,7 +10,7 @@ package org.dicekeys.crypto.seeded
  * [getSignatureVerificationKey].
  * 
  * The key pair of the [SigningKey] and [SignatureVerificationKey] is generated
- * from a seed and a set of key-derivation specified options in [derivationOptionsJson]
+ * from a seed and a set of key-derivation specified options in [recipe]
  *
  * This class wraps the native c++ SigningKey class from the
  * DiceKeys [Seeded Cryptography Library](https://dicekeys.github.io/seeded-crypto/).
@@ -25,18 +25,18 @@ class SigningKey internal constructor(
         }
         @JvmStatic private external fun constructJNI(
                 signingKeyBytes: ByteArray,
-                derivationOptionsJson: String
+                recipe: String
         ) : Long
 
         @JvmStatic private external fun constructJNI(
                 signingKeyBytes: ByteArray,
                 signatureVerificationKeyBytes: ByteArray,
-                derivationOptionsJson: String
+                recipe: String
         ) : Long
 
         @JvmStatic private external fun deriveFromSeedJNI(
                 seedString: String,
-                derivationOptionsJson: String
+                recipe: String
         ) : Long
 
         /**
@@ -45,8 +45,8 @@ class SigningKey internal constructor(
          */
         fun deriveFromSeed(
                 seedString: String,
-                derivationOptionsJson: String
-        ) = SigningKey (deriveFromSeedJNI(seedString, derivationOptionsJson))
+                recipe: String
+        ) = SigningKey (deriveFromSeedJNI(seedString, recipe))
 
 
         @JvmStatic private external fun fromJsonJNI(signingKeyAsJson: String) : Long
@@ -89,7 +89,7 @@ class SigningKey internal constructor(
     constructor(other: SigningKey) : this(
             other.signingKeyBytes,
             other.signatureVerificationKeyBytes,
-            other.derivationOptionsJson)
+            other.recipe)
 
     /**
      * Construct by reconstituting its members (including [signatureVerificationKeyBytes])
@@ -97,8 +97,8 @@ class SigningKey internal constructor(
     internal constructor(
             signingKeyBytes: ByteArray,
             signatureVerificationKeyBytes: ByteArray,
-            derivationOptionsJson: String
-    ) : this(constructJNI(signingKeyBytes, signatureVerificationKeyBytes, derivationOptionsJson))
+            recipe: String
+    ) : this(constructJNI(signingKeyBytes, signatureVerificationKeyBytes, recipe))
 
     /**
      * Construct by reconstituting its members (excluding [signatureVerificationKeyBytes], which
@@ -106,14 +106,14 @@ class SigningKey internal constructor(
      */
     internal constructor(
             signingKeyBytes: ByteArray,
-            derivationOptionsJson: String
-    ) : this(constructJNI(signingKeyBytes, derivationOptionsJson))
+            recipe: String
+    ) : this(constructJNI(signingKeyBytes, recipe))
 
     private external fun deleteNativeObjectPtrJNI()
     private external fun getSignatureVerificationKeyJNI() : Long
     private external fun signatureVerificationKeyBytesGetterJNI(): ByteArray
     private external fun signingKeyBytesGetterJNI(): ByteArray
-    private external fun derivationOptionsJsonGetterJNI(): String
+    private external fun recipeGetterJNI(): String
     external fun generateSignature(message: ByteArray): ByteArray
 
     /**
@@ -180,11 +180,11 @@ class SigningKey internal constructor(
     /**
      * Get the key-derivation options used to generate this [SigningKey]
      */
-    val derivationOptionsJson get() = derivationOptionsJsonGetterJNI()
+    val recipe get() = recipeGetterJNI()
 
     override fun equals(other: Any?): Boolean =
             (other is SigningKey) &&
-                    derivationOptionsJson == other.derivationOptionsJson &&
+                    recipe == other.recipe &&
                     signingKeyBytes.contentEquals(other.signingKeyBytes) &&
                     signatureVerificationKeyBytes.contentEquals(other.signatureVerificationKeyBytes)
 

--- a/seeded/src/main/java/org/dicekeys/crypto/seeded/SymmetricKey.kt
+++ b/seeded/src/main/java/org/dicekeys/crypto/seeded/SymmetricKey.kt
@@ -7,7 +7,7 @@ package org.dicekeys.crypto.seeded
  * So, you can use this symmetric-key to seal a message, throw the
  * key away, and re-generate the key when you need to unseal the
  * message so long as you still have the original seed and
- * derivationOptionsJson.
+ * recipe.
  *  
  * Sealing a message (_plaintext_) creates a _ciphertext which contains
  * the message but from which observers who do not have the PrivateKey
@@ -38,22 +38,22 @@ class SymmetricKey private constructor(
 
         @JvmStatic private external fun constructJNI(
             keyBytes: ByteArray,
-            derivationOptionsJson: String
+            recipe: String
         ) : Long
         @JvmStatic private external fun deriveFromSeedJNI(
             seedString: String,
-            derivationOptionsJson: String
+            recipe: String
         ) : Long
 
         /**
          * Construct a symmetric key from a secret [seedString], which should have enough
          * entropy to make it hard to guess (e.g. 128+ bits) and a set of public (non-secret)
-         * key-derivation options ([derivationOptionsJson]).
+         * key-derivation options ([recipe]).
          */
         @JvmStatic fun deriveFromSeed(
             seedString: String,
-            derivationOptionsJson: String
-        ) : SymmetricKey = SymmetricKey(deriveFromSeedJNI(seedString, derivationOptionsJson))
+            recipe: String
+        ) : SymmetricKey = SymmetricKey(deriveFromSeedJNI(seedString, recipe))
 
 
         @JvmStatic private external fun fromJsonJNI(
@@ -93,7 +93,7 @@ class SymmetricKey private constructor(
             seedString: String
         ) : ByteArray {
             return deriveFromSeed(
-                seedString, packagedSealedMessage.derivationOptionsJson
+                seedString, packagedSealedMessage.recipe
             ).unseal(
                 packagedSealedMessage.ciphertext,
                 packagedSealedMessage.unsealingInstructions
@@ -109,7 +109,7 @@ class SymmetricKey private constructor(
 
     private external fun deleteNativeObjectPtrJNI()
     private external fun keyBytesGetterJNI(): ByteArray
-    private external fun derivationOptionsJsonGetterJNI(): String
+    private external fun recipeGetterJNI(): String
 
     /**
      * Convert this symmetric key to JSON-format string so that it can be later reconstituted
@@ -129,16 +129,16 @@ class SymmetricKey private constructor(
     /**
      * The options that guided the derivation of this key from the seed.
      */
-    val derivationOptionsJson: String get() = derivationOptionsJsonGetterJNI()
+    val recipe: String get() = recipeGetterJNI()
 
     /**
      * Construct this object manually by passing the [keyBytes] and the
-     * [derivationOptionsJson] that was used in the derivation of [keyBytes].
+     * [recipe] that was used in the derivation of [keyBytes].
      */
     internal constructor(
         keyBytes: ByteArray,
-        derivationOptionsJson: String
-    ) : this( constructJNI(keyBytes, derivationOptionsJson) )
+        recipe: String
+    ) : this( constructJNI(keyBytes, recipe) )
 
     /**
      * A copy constructor to prevent copying of the native pointer, which would lead
@@ -146,7 +146,7 @@ class SymmetricKey private constructor(
      */
     internal constructor(
         other: SymmetricKey
-    ) : this(other.keyBytes, other.derivationOptionsJson)
+    ) : this(other.keyBytes, other.recipe)
 
     protected fun finalize() {
         deleteNativeObjectPtrJNI()
@@ -194,7 +194,7 @@ class SymmetricKey private constructor(
      *
      * Returns a [PackagedSealedMessage] containing not only the ciphertext, but the
      * plaintext [unsealingInstructions] the message was sealed with, which
-     * are required for unsealing, as well as the [derivationOptionsJson] used to
+     * are required for unsealing, as well as the [recipe] used to
      * construct this [SymmetricKey] in case it needs to be re-derived from the
      * original secret seed.
      */

--- a/seeded/src/main/java/org/dicekeys/crypto/seeded/UnsealingKey.kt
+++ b/seeded/src/main/java/org/dicekeys/crypto/seeded/UnsealingKey.kt
@@ -27,11 +27,11 @@ class UnsealingKey private constructor(
         @JvmStatic private external fun constructJNI(
             privateKeyBytes: ByteArray,
             publicKeyBytes: ByteArray,
-            derivationOptionsJson: String
+            recipe: String
         ) : Long
         @JvmStatic private external fun deriveFromSeedJNI(
             seedString: String,
-            derivationOptionsJson: String
+            recipe: String
         ) : Long
 
         /**
@@ -40,8 +40,8 @@ class UnsealingKey private constructor(
          */
         fun deriveFromSeed(
                 seedString: String,
-                derivationOptionsJson: String
-        ) = UnsealingKey(deriveFromSeedJNI(seedString, derivationOptionsJson))
+                recipe: String
+        ) = UnsealingKey(deriveFromSeedJNI(seedString, recipe))
 
 
 
@@ -73,7 +73,7 @@ class UnsealingKey private constructor(
 
         /**
          * Unseal a message by re-deriving the [UnsealingKey] from the secret [seedString]
-         * used to originally derive it.  The [PackagedSealedMessage.derivationOptionsJson]
+         * used to originally derive it.  The [PackagedSealedMessage.recipe]
          * needed to derive it is in the [packagedSealedMessage], as are the
          * [PackagedSealedMessage.ciphertext] and
          * [PackagedSealedMessage.unsealingInstructions].
@@ -83,7 +83,7 @@ class UnsealingKey private constructor(
                 packagedSealedMessage: PackagedSealedMessage
         ) : ByteArray {
             return deriveFromSeed(
-                seedString, packagedSealedMessage.derivationOptionsJson
+                seedString, packagedSealedMessage.recipe
             ).unseal(
                 packagedSealedMessage.ciphertext,
                 packagedSealedMessage.unsealingInstructions
@@ -102,7 +102,7 @@ class UnsealingKey private constructor(
     private external fun deleteNativeObjectPtrJNI()
     private external fun unsealingKeyBytesGetterJNI(): ByteArray
     private external fun sealingKeyBytesGetterJNI(): ByteArray
-    private external fun derivationOptionsJsonGetterJNI(): String
+    private external fun recipeGetterJNI(): String
     external override fun toJson(): String
 
     /**
@@ -111,13 +111,13 @@ class UnsealingKey private constructor(
      */
     constructor(
         other: UnsealingKey
-    ) : this(other.unsealingKeyBytes, other.sealingKeyBytes, other.derivationOptionsJson)
+    ) : this(other.unsealingKeyBytes, other.sealingKeyBytes, other.recipe)
 
     internal constructor(
         privateKeyBytes: ByteArray,
         publicKeyBytes: ByteArray,
-        derivationOptionsJson: String
-    ) : this( constructJNI(privateKeyBytes, publicKeyBytes, derivationOptionsJson))
+        recipe: String
+    ) : this( constructJNI(privateKeyBytes, publicKeyBytes, recipe))
 
     protected fun finalize() {
         deleteNativeObjectPtrJNI()
@@ -152,11 +152,11 @@ class UnsealingKey private constructor(
     /**
      * The options that guided the derivation of this key from the seed.
      */
-    val derivationOptionsJson get() = derivationOptionsJsonGetterJNI()
+    val recipe get() = recipeGetterJNI()
 
     override fun equals(other: Any?): Boolean =
             (other is UnsealingKey) &&
-                    derivationOptionsJson == other.derivationOptionsJson &&
+                    recipe == other.recipe &&
                     unsealingKeyBytes.contentEquals(other.unsealingKeyBytes) &&
                     sealingKeyBytes.contentEquals(other.sealingKeyBytes)
 

--- a/trustedapp/src/main/java/org/dicekeys/trustedapp/apicommands/permissionchecked/PermissionCheckedCommands.kt
+++ b/trustedapp/src/main/java/org/dicekeys/trustedapp/apicommands/permissionchecked/PermissionCheckedCommands.kt
@@ -147,7 +147,7 @@ class PermissionCheckedCommands(
           DerivationOptions.Type.UnsealingKey,
           ApiStrings.Commands.unsealWithUnsealingKey
         ),
-        packagedSealedMessage.derivationOptionsJson
+        packagedSealedMessage.recipe
       ).unseal(packagedSealedMessage)
 
   /**

--- a/trustedapp/src/main/java/org/dicekeys/trustedapp/apicommands/permissionchecked/PermissionCheckedSeedAccessor.kt
+++ b/trustedapp/src/main/java/org/dicekeys/trustedapp/apicommands/permissionchecked/PermissionCheckedSeedAccessor.kt
@@ -122,7 +122,7 @@ open class PermissionCheckedSeedAccessor(
   ): String {
     permissionChecks.throwIfUnsealingInstructionsViolated(packagedSealedMessage.unsealingInstructions)
     return getSeedOrThrowIfClientNotAuthorized(
-      packagedSealedMessage.derivationOptionsJson,
+      packagedSealedMessage.recipe,
       type,
       command
     )


### PR DESCRIPTION
Update use of the SeedecCrypto library as the library has renamed `derivationOptionsJson` to `recipe`.

See also

https://github.com/dicekeys/seeded-crypto/pull/5
https://github.com/dicekeys/seeded-crypto-ios/pull/15
https://github.com/dicekeys/dicekeys-app-ios/pull/108