### PR TITLE
Replace `derivationOptionsJson` with `recipeJson`/`recipe`

### DIFF
--- a/api/src/main/java/org/dicekeys/api/Api.kt
+++ b/api/src/main/java/org/dicekeys/api/Api.kt
@@ -58,15 +58,15 @@ abstract class Api(
 
     /**
      * Sign a [message] using a public/private signing key pair derived
-     * from the user's DiceKey and the [ApiDerivationOptions] specified in JSON format via
-     * [derivationOptionsJson].
+     * from the user's DiceKey and the [ApiRecipe] specified in JSON format via
+     * [recipeJson].
      */
     override suspend fun generateSignature(
-      derivationOptionsJson: String,
+      recipeJson: String,
       message: ByteArray
     ): GenerateSignatureResult =
-      generateSignatureMarshaller.call(authTokenIfRequired(ApiDerivationOptions(derivationOptionsJson))) {
-        marshallParameter(Inputs.generateSignature::derivationOptionsJson.name, derivationOptionsJson )
+      generateSignatureMarshaller.call(authTokenIfRequired(ApiRecipe(recipeJson))) {
+        marshallParameter(Inputs.generateSignature::recipeJson.name, recipeJson )
         marshallParameter(Inputs.generateSignature::message.name, message)
       }
 
@@ -82,14 +82,14 @@ abstract class Api(
 
     /**
      * Derive a pseudo-random cryptographic [Secret] from the user's DiceKey and
-     * the key-derivation options passed as [derivationOptionsJson]
+     * the key-derivation options passed as [recipeJson]
      * in [Recipe JSON Format](https://dicekeys.github.io/seeded-crypto/recipe_format.html).
      */
     override suspend fun getSecret(
-      derivationOptionsJson: String
+      recipeJson: String
     ): Secret =
-      getSecretMarshaller.call(authTokenIfRequired(ApiDerivationOptions(derivationOptionsJson))) {
-        marshallParameter(Inputs.getSecret::derivationOptionsJson.name, derivationOptionsJson)
+      getSecretMarshaller.call(authTokenIfRequired(ApiRecipe(recipeJson))) {
+        marshallParameter(Inputs.getSecret::recipeJson.name, recipeJson)
       }
 
     private val getSecretMarshaller =
@@ -100,16 +100,16 @@ abstract class Api(
 
     /**
      * Get a [UnsealingKey] derived from the user's DiceKey (the seed) and the key-derivation options
-     * specified via [derivationOptionsJson],
+     * specified via [recipeJson],
      * in [Recipe JSON Format](https://dicekeys.github.io/seeded-crypto/recipe_format.html),
      * which must specify
      *  `"clientMayRetrieveKey": true`.
      */
     override suspend fun getUnsealingKey(
-      derivationOptionsJson: String
+      recipeJson: String
     ): UnsealingKey =
-      getUnsealingKeyMarshaller.call(authTokenIfRequired(ApiDerivationOptions(derivationOptionsJson))) {
-        marshallParameter(Inputs.getUnsealingKey::derivationOptionsJson.name, derivationOptionsJson)
+      getUnsealingKeyMarshaller.call(authTokenIfRequired(ApiRecipe(recipeJson))) {
+        marshallParameter(Inputs.getUnsealingKey::recipeJson.name, recipeJson)
       }
 
     private val getUnsealingKeyMarshaller =
@@ -120,16 +120,16 @@ abstract class Api(
 
     /**
      * Get a [SymmetricKey] derived from the user's DiceKey (the seed) and the key-derivation options
-     * specified via [derivationOptionsJson],
+     * specified via [recipeJson],
      * in [Recipe JSON Format](https://dicekeys.github.io/seeded-crypto/recipe_format.html),
      * which must specify
      *  `"clientMayRetrieveKey": true`.
      */
     override suspend fun getSymmetricKey(
-      derivationOptionsJson: String
+      recipeJson: String
     ): SymmetricKey =
-      getSymmetricKeyMarshaller.call(authTokenIfRequired(ApiDerivationOptions(derivationOptionsJson))) {
-        marshallParameter(Inputs.getSymmetricKey::derivationOptionsJson.name, derivationOptionsJson)
+      getSymmetricKeyMarshaller.call(authTokenIfRequired(ApiRecipe(recipeJson))) {
+        marshallParameter(Inputs.getSymmetricKey::recipeJson.name, recipeJson)
       }
 
     private val getSymmetricKeyMarshaller =
@@ -139,16 +139,16 @@ abstract class Api(
 
     /**
      * Get a [SigningKey] derived from the user's DiceKey (the seed) and the key-derivation options
-     * specified via [derivationOptionsJson],
+     * specified via [recipeJson],
      * in [Recipe JSON Format](https://dicekeys.github.io/seeded-crypto/recipe_format.html),
      * which must specify
      *  `"clientMayRetrieveKey": true`.
      */
     override suspend fun getSigningKey(
-      derivationOptionsJson: String
+      recipeJson: String
     ): SigningKey =
-      getSigningKeyMarshaller.call(authTokenIfRequired(ApiDerivationOptions(derivationOptionsJson))) {
-        marshallParameter(Inputs.getSigningKey::derivationOptionsJson.name, derivationOptionsJson)
+      getSigningKeyMarshaller.call(authTokenIfRequired(ApiRecipe(recipeJson))) {
+        marshallParameter(Inputs.getSigningKey::recipeJson.name, recipeJson)
       }
 
     private val getSigningKeyMarshaller =
@@ -158,15 +158,15 @@ abstract class Api(
 
 
     /**
-     * Get a [SealingKey] derived from the user's DiceKey and the [ApiDerivationOptions] specified
+     * Get a [SealingKey] derived from the user's DiceKey and the [ApiRecipe] specified
      * in [Recipe JSON Format](https://dicekeys.github.io/seeded-crypto/recipe_format.html)
-     * as [derivationOptionsJson].
+     * as [recipeJson].
      */
     override suspend fun getSealingKey(
-      derivationOptionsJson: String
+      recipeJson: String
     ): SealingKey =
-      getSealingKeyMarshaller.call(authTokenIfRequired(ApiDerivationOptions(derivationOptionsJson))) {
-        marshallParameter(Inputs.getSealingKey::derivationOptionsJson.name, derivationOptionsJson)
+      getSealingKeyMarshaller.call(authTokenIfRequired(ApiRecipe(recipeJson))) {
+        marshallParameter(Inputs.getSealingKey::recipeJson.name, recipeJson)
       }
 
     private val getSealingKeyMarshaller =
@@ -188,7 +188,7 @@ abstract class Api(
       packagedSealedMessage: PackagedSealedMessage
     ): ByteArray =
       unsealWithUnsealingKeyMarshaller.call(
-        authTokenIfRequired(ApiDerivationOptions(packagedSealedMessage.recipe)) ?:
+        authTokenIfRequired(ApiRecipe(packagedSealedMessage.recipe)) ?:
         authTokenIfRequired(UnsealingInstructions(packagedSealedMessage.unsealingInstructions))
       ) {
         marshallParameter(Inputs.unsealWithUnsealingKey.packagedSealedMessageJson, packagedSealedMessage)
@@ -203,19 +203,19 @@ abstract class Api(
     /**
      * Seal (encrypt with a message-authentication code) a message ([plaintext]) with a
      * symmetric key derived from the user's DiceKey, the
-     * [derivationOptionsJson]
+     * [recipeJson]
      * in [Recipe JSON Format](https://dicekeys.github.io/seeded-crypto/recipe_format.html),
      * and [UnsealingInstructions] specified via a JSON string as
      * [unsealingInstructions] in the
      * in [Post-Decryption Instructions JSON Format](https://dicekeys.github.io/seeded-crypto/unsealing_instructions_format.html).
      */
     override suspend fun sealWithSymmetricKey(
-      derivationOptionsJson: String,
+      recipeJson: String,
       plaintext: ByteArray,
       unsealingInstructions: String
     ): PackagedSealedMessage =
-      sealWithSymmetricKeyMarshaller.call(authTokenIfRequired(ApiDerivationOptions(derivationOptionsJson))) {
-        marshallParameter(Inputs.sealWithSymmetricKey::derivationOptionsJson.name, derivationOptionsJson)
+      sealWithSymmetricKeyMarshaller.call(authTokenIfRequired(ApiRecipe(recipeJson))) {
+        marshallParameter(Inputs.sealWithSymmetricKey::recipeJson.name, recipeJson)
         marshallParameter(Inputs.sealWithSymmetricKey::plaintext.name, plaintext)
         marshallParameter(Inputs.sealWithSymmetricKey::unsealingInstructions.name, unsealingInstructions)
       }
@@ -229,7 +229,7 @@ abstract class Api(
     /**
      * Unseal (decrypt & authenticate) a [packagedSealedMessage] that was previously sealed with a
      * symmetric key derived from the user's DiceKey, the
-     * [ApiDerivationOptions] specified in JSON format via [PackagedSealedMessage.derivationOptionsJson],
+     * [ApiRecipe] specified in JSON format via [PackagedSealedMessage.recipeJson],
      * and any [UnsealingInstructions] optionally specified by [PackagedSealedMessage.unsealingInstructions]
      * in [Post-Decryption Instructions JSON Format](https://dicekeys.github.io/seeded-crypto/unsealing_instructions_format.html).
      *
@@ -240,7 +240,7 @@ abstract class Api(
       packagedSealedMessage: PackagedSealedMessage
     ): ByteArray =
       unsealWithSymmetricKeyMarshaller.call(
-        authTokenIfRequired(ApiDerivationOptions(packagedSealedMessage.recipe)) ?:
+        authTokenIfRequired(ApiRecipe(packagedSealedMessage.recipe)) ?:
         authTokenIfRequired(UnsealingInstructions(packagedSealedMessage.unsealingInstructions))
       ) {
         marshallParameter(Inputs.unsealWithSymmetricKey.packagedSealedMessageJson, packagedSealedMessage)
@@ -254,13 +254,13 @@ abstract class Api(
 
     /**
      * Get a public [SignatureVerificationKey] derived from the user's DiceKey and the
-     * [ApiDerivationOptions] specified in JSON format via [derivationOptionsJson]
+     * [ApiRecipe] specified in JSON format via [recipeJson]
      */
     override suspend fun getSignatureVerificationKey(
-      derivationOptionsJson: String
+      recipeJson: String
     ): SignatureVerificationKey =
-      getSignatureVerificationKeyMarshaller.call(authTokenIfRequired(ApiDerivationOptions(derivationOptionsJson))) {
-        marshallParameter(Inputs.getSignatureVerificationKey::derivationOptionsJson.name, derivationOptionsJson)
+      getSignatureVerificationKeyMarshaller.call(authTokenIfRequired(ApiRecipe(recipeJson))) {
+        marshallParameter(Inputs.getSignatureVerificationKey::recipeJson.name, recipeJson)
       }
 
     private val getSignatureVerificationKeyMarshaller =
@@ -274,48 +274,48 @@ abstract class Api(
 
 
     override fun generateSignatureAsync(
-      derivationOptionsJson: String,
+      recipeJson: String,
       message: ByteArray
     ): Deferred<GenerateSignatureResult> = CoroutineScope(Dispatchers.Default).async {
-      generateSignature(derivationOptionsJson, message) }
+      generateSignature(recipeJson, message) }
 
     override fun getSealingKeyAsync(
-      derivationOptionsJson: String
+      recipeJson: String
     ): Deferred<SealingKey> = CoroutineScope(Dispatchers.Default).async {
-      getSealingKey(derivationOptionsJson) }
+      getSealingKey(recipeJson) }
 
     override fun getSecretAsync(
-      derivationOptionsJson: String
+      recipeJson: String
     ): Deferred<Secret> = CoroutineScope(Dispatchers.Default).async {
-      getSecret(derivationOptionsJson) }
+      getSecret(recipeJson) }
 
     override fun getSignatureVerificationKeyAsync(
-      derivationOptionsJson: String
+      recipeJson: String
     ): Deferred<SignatureVerificationKey> = CoroutineScope(Dispatchers.Default).async {
-      getSignatureVerificationKey(derivationOptionsJson) }
+      getSignatureVerificationKey(recipeJson) }
 
     override fun getSigningKeyAsync(
-      derivationOptionsJson: String
+      recipeJson: String
     ): Deferred<SigningKey> = CoroutineScope(Dispatchers.Default).async {
-      getSigningKey(derivationOptionsJson) }
+      getSigningKey(recipeJson) }
 
     override fun getSymmetricKeyAsync(
-      derivationOptionsJson: String
+      recipeJson: String
     ): Deferred<SymmetricKey> = CoroutineScope(Dispatchers.Default).async {
-      getSymmetricKey(derivationOptionsJson) }
+      getSymmetricKey(recipeJson) }
 
     override fun getUnsealingKeyAsync(
-      derivationOptionsJson: String
+      recipeJson: String
     ): Deferred<UnsealingKey> = CoroutineScope(Dispatchers.Default).async {
-      getUnsealingKey(derivationOptionsJson) }
+      getUnsealingKey(recipeJson) }
 
     override fun sealWithSymmetricKeyAsync(
-      derivationOptionsJson: String,
+      recipeJson: String,
       plaintext: ByteArray,
       unsealingInstructions: String
     ): Deferred<PackagedSealedMessage> = CoroutineScope(Dispatchers.Default).async {
       sealWithSymmetricKey(
-      derivationOptionsJson, plaintext, unsealingInstructions
+      recipeJson, plaintext, unsealingInstructions
     ) }
 
 
@@ -344,50 +344,50 @@ abstract class Api(
     }
 
     override fun generateSignature(
-      derivationOptionsJson: String,
+      recipeJson: String,
       message: ByteArray,
       callback: CallbackApi.Callback<GenerateSignatureResult>?
     ) = toCallback(callback) { generateSignature(
-      derivationOptionsJson, message
+      recipeJson, message
     )}
 
     override fun getSealingKey(
-      derivationOptionsJson: String,
+      recipeJson: String,
       callback: CallbackApi.Callback<SealingKey>?
-    ) = toCallback(callback) { getSealingKey(derivationOptionsJson) }
+    ) = toCallback(callback) { getSealingKey(recipeJson) }
 
     override fun getSecret(
-      derivationOptionsJson: String,
+      recipeJson: String,
       callback: CallbackApi.Callback<Secret>?
-    ) = toCallback(callback) { getSecret(derivationOptionsJson) }
+    ) = toCallback(callback) { getSecret(recipeJson) }
 
     override fun getSignatureVerificationKey(
-      derivationOptionsJson: String,
+      recipeJson: String,
       callback: CallbackApi.Callback<SignatureVerificationKey>?
-    ) = toCallback(callback) { getSignatureVerificationKey(derivationOptionsJson) }
+    ) = toCallback(callback) { getSignatureVerificationKey(recipeJson) }
 
     override fun getSigningKey(
-      derivationOptionsJson: String,
+      recipeJson: String,
       callback: CallbackApi.Callback<SigningKey>?
-    ) = toCallback(callback) { getSigningKey(derivationOptionsJson) }
+    ) = toCallback(callback) { getSigningKey(recipeJson) }
 
     override fun getSymmetricKey(
-      derivationOptionsJson: String,
+      recipeJson: String,
       callback: CallbackApi.Callback<SymmetricKey>?
-    ) = toCallback(callback) { getSymmetricKey(derivationOptionsJson) }
+    ) = toCallback(callback) { getSymmetricKey(recipeJson) }
 
     override fun getUnsealingKey(
-      derivationOptionsJson: String,
+      recipeJson: String,
       callback: CallbackApi.Callback<UnsealingKey>?
-    ) = toCallback(callback) { getUnsealingKey(derivationOptionsJson) }
+    ) = toCallback(callback) { getUnsealingKey(recipeJson) }
 
     override fun sealWithSymmetricKey(
-      derivationOptionsJson: String,
+      recipeJson: String,
       plaintext: ByteArray,
       unsealingInstructions: String,
       callback: CallbackApi.Callback<PackagedSealedMessage>
     ) = toCallback(callback) { sealWithSymmetricKey(
-      derivationOptionsJson, plaintext, unsealingInstructions
+      recipeJson, plaintext, unsealingInstructions
     ) }
 
     override fun unsealWithSymmetricKey(

--- a/api/src/main/java/org/dicekeys/api/ApiRecipe.kt
+++ b/api/src/main/java/org/dicekeys/api/ApiRecipe.kt
@@ -10,7 +10,7 @@ import org.json.JSONObject
  * [Recipe JSON Format](https://dicekeys.github.io/seeded-crypto/recipe_format.html),
  * which specify how to derive cryptographic keys from seed string.
  * These JSON strings appear throughout the API (and in the [DiceKeysIntentApiClient]) as a
- * parameter named _derivationOptionsJson_.
+ * parameter named _recipeJson_.
  *
  * This implementation extends of the more general [DerivationOptions] class, which
  * abstracts all the general-purpose key-derivation options that aren't specific
@@ -28,7 +28,7 @@ import org.json.JSONObject
  * seeds that remain the same even if the orientation of a die within a DiceKey changes.
  *
  *
- * @sample [ApiSamples.sampleOfApiDerivationOptions]
+ * @sample [ApiSamples.sampleOfApiRecipe]
  *
 
  * ```
@@ -42,12 +42,12 @@ import org.json.JSONObject
  * For example [Symmetric] for the derivation options of a symmetric key.  If you pass nothing,
  * empty options will be created, which you can then configure (e.g., via _apply).
  */
-open class ApiDerivationOptions constructor(
-  derivationOptionsJson: String? = null,
+open class ApiRecipe constructor(
+  recipeJson: String? = null,
   requiredType: Type? = null
 ):  AuthenticationRequirements,
     DerivationOptions(
-      derivationOptionsJson, requiredType
+      recipeJson, requiredType
 ) {
 
     /**
@@ -65,8 +65,8 @@ open class ApiDerivationOptions constructor(
      * specified [Restrictions] are not met.
      */
     var clientMayRetrieveKey: Boolean?
-        get () = optBoolean(ApiDerivationOptions::clientMayRetrieveKey.name, false)
-        set(value)  { put(ApiDerivationOptions::clientMayRetrieveKey.name, value) }
+        get () = optBoolean(ApiRecipe::clientMayRetrieveKey.name, false)
+        set(value)  { put(ApiRecipe::clientMayRetrieveKey.name, value) }
 
 
 
@@ -120,40 +120,40 @@ open class ApiDerivationOptions constructor(
      * For a key of 25 dice, it reduces the entropy by 50 (2x25) bits, from ~196 bits to ~146 bits.
      */
     var excludeOrientationOfFaces: Boolean
-        get () = optBoolean(ApiDerivationOptions::excludeOrientationOfFaces.name, false)
-        set(value) { put(ApiDerivationOptions::excludeOrientationOfFaces.name, value) }
+        get () = optBoolean(ApiRecipe::excludeOrientationOfFaces.name, false)
+        set(value) { put(ApiRecipe::excludeOrientationOfFaces.name, value) }
 
 
     /**
      * An extension class that must represent a specification for a public/private key pair
      */
-    class UnsealingKey(derivationOptionsJson: String? = null) :
-            ApiDerivationOptions(derivationOptionsJson,  Type.UnsealingKey)
+    class UnsealingKey(recipeJson: String? = null) :
+            ApiRecipe(recipeJson,  Type.UnsealingKey)
 
 
     /**
      * An extension class that must represent a specification for a derived seed
      */
-    class Password(derivationOptionsJson: String? = null) :
-      ApiDerivationOptions(derivationOptionsJson,  Type.Password)
+    class Password(recipeJson: String? = null) :
+      ApiRecipe(recipeJson,  Type.Password)
 
 
   /**
      * An extension class that must represent a specification for a derived seed
      */
-    class Secret(derivationOptionsJson: String? = null) :
-            ApiDerivationOptions(derivationOptionsJson,  Type.Secret)
+    class Secret(recipeJson: String? = null) :
+            ApiRecipe(recipeJson,  Type.Secret)
 
     /**
      * An extension class that must represent a specification for a signing/verification key pair
      */
-    class SigningKey(derivationOptionsJson: String? = null) :
-            ApiDerivationOptions(derivationOptionsJson,  Type.SigningKey)
+    class SigningKey(recipeJson: String? = null) :
+            ApiRecipe(recipeJson,  Type.SigningKey)
 
     /**
      * An extension class that must represent a specification for a symmetric key
      */
-    class SymmetricKey(derivationOptionsJson: String? = null) :
-            ApiDerivationOptions(derivationOptionsJson,  Type.SymmetricKey)
+    class SymmetricKey(recipeJson: String? = null) :
+            ApiRecipe(recipeJson,  Type.SymmetricKey)
 
 }

--- a/api/src/main/java/org/dicekeys/api/ApiStrings.kt
+++ b/api/src/main/java/org/dicekeys/api/ApiStrings.kt
@@ -27,40 +27,40 @@ class ApiStrings {
 
   object Inputs {
     object generateSignature {
-      const val derivationOptionsJson = "derivationOptionsJson"
+      const val recipeJson = "recipe"
       const val message = "message"
     }
     object getPassword {
-      const val derivationOptionsJson = "derivationOptionsJson"
-      const val derivationOptionsJsonMayBeModified = "derivationOptionsJsonMayBeModified"
+      const val recipeJson = "recipe"
+      const val recipeJsonMayBeModified = "recipeJsonMayBeModified"
     }
     object getSealingKey {
-      const val derivationOptionsJson = "derivationOptionsJson"
-      const val derivationOptionsJsonMayBeModified = "derivationOptionsJsonMayBeModified"
+      const val recipeJson = "recipe"
+      const val recipeJsonMayBeModified = "recipeJsonMayBeModified"
     }
     object getSecret {
-      const val derivationOptionsJson = "derivationOptionsJson"
-      const val derivationOptionsJsonMayBeModified = "derivationOptionsJsonMayBeModified"
+      const val recipeJson = "recipe"
+      const val recipeJsonMayBeModified = "recipeJsonMayBeModified"
     }
     object getSigningKey {
-      const val derivationOptionsJson = "derivationOptionsJson"
-      const val derivationOptionsJsonMayBeModified = "derivationOptionsJsonMayBeModified"
+      const val recipeJson = "recipe"
+      const val recipeJsonMayBeModified = "recipeJsonMayBeModified"
     }
     object getSignatureVerificationKey {
-      const val derivationOptionsJson = "derivationOptionsJson"
-      const val derivationOptionsJsonMayBeModified = "derivationOptionsJsonMayBeModified"
+      const val recipeJson = "recipe"
+      const val recipeJsonMayBeModified = "recipeJsonMayBeModified"
     }
     object getSymmetricKey {
-      const val derivationOptionsJson = "derivationOptionsJson"
-      const val derivationOptionsJsonMayBeModified = "derivationOptionsJsonMayBeModified"
+      const val recipeJson = "recipe"
+      const val recipeJsonMayBeModified = "recipeJsonMayBeModified"
     }
     object getUnsealingKey {
-      const val derivationOptionsJson = "derivationOptionsJson"
-      const val derivationOptionsJsonMayBeModified = "derivationOptionsJsonMayBeModified"
+      const val recipeJson = "recipe"
+      const val recipeJsonMayBeModified = "recipeJsonMayBeModified"
     }
     object sealWithSymmetricKey {
-      const val derivationOptionsJson = "derivationOptionsJson"
-      const val derivationOptionsJsonMayBeModified = "derivationOptionsJsonMayBeModified"
+      const val recipeJson = "recipe"
+      const val recipeJsonMayBeModified = "recipeJsonMayBeModified"
       const val plaintext = "plaintext"
       const val unsealingInstructions = "unsealingInstructions"
     }

--- a/api/src/main/java/org/dicekeys/api/AsyncApi.kt
+++ b/api/src/main/java/org/dicekeys/api/AsyncApi.kt
@@ -6,23 +6,23 @@ import org.dicekeys.crypto.seeded.*
 interface AsyncApi {
 
   fun getSecretAsync(
-    derivationOptionsJson: String
+    recipeJson: String
   ): Deferred<Secret>
 
   fun getUnsealingKeyAsync(
-    derivationOptionsJson: String
+    recipeJson: String
   ): Deferred<UnsealingKey>
 
   fun getSymmetricKeyAsync(
-    derivationOptionsJson: String
+    recipeJson: String
   ): Deferred<SymmetricKey>
 
   fun getSigningKeyAsync(
-    derivationOptionsJson: String
+    recipeJson: String
   ): Deferred<SigningKey>
 
   fun getSealingKeyAsync(
-    derivationOptionsJson: String
+    recipeJson: String
   ): Deferred<SealingKey>
 
   fun unsealWithUnsealingKeyAsync(
@@ -30,7 +30,7 @@ interface AsyncApi {
   ): Deferred<ByteArray>
 
   fun sealWithSymmetricKeyAsync(
-    derivationOptionsJson: String,
+    recipeJson: String,
     plaintext: ByteArray,
     unsealingInstructions: String = ""
   ): Deferred<PackagedSealedMessage>
@@ -40,11 +40,11 @@ interface AsyncApi {
   ): Deferred<ByteArray>
 
   fun getSignatureVerificationKeyAsync(
-    derivationOptionsJson: String
+    recipeJson: String
   ): Deferred<SignatureVerificationKey>
 
   fun generateSignatureAsync(
-    derivationOptionsJson: String,
+    recipeJson: String,
     message: ByteArray
   ): Deferred<GenerateSignatureResult>
 

--- a/api/src/main/java/org/dicekeys/api/CallbackApi.kt
+++ b/api/src/main/java/org/dicekeys/api/CallbackApi.kt
@@ -17,55 +17,55 @@ interface CallbackApi {
   }
 
   fun getSecret(
-    derivationOptionsJson: String,
+    recipeJson: String,
     callback: Callback<Secret>? = null
   )
 
   /**
    * Get a [UnsealingKey] derived from the user's DiceKey (the seed) and the key-derivation options
-   * specified via [derivationOptionsJson],
+   * specified via [recipeJson],
    * in [Recipe JSON Format](https://dicekeys.github.io/seeded-crypto/recipe_format.html),
    * which must specify
    *  `"clientMayRetrieveKey": true`.
    */
   fun getUnsealingKey(
-    derivationOptionsJson: String,
+    recipeJson: String,
     callback: Callback<UnsealingKey>? = null
   )
 
 
   /**
    * Get a [SymmetricKey] derived from the user's DiceKey (the seed) and the key-derivation options
-   * specified via [derivationOptionsJson],
+   * specified via [recipeJson],
    * in [Recipe JSON Format](https://dicekeys.github.io/seeded-crypto/recipe_format.html),
    * which must specify
    *  `"clientMayRetrieveKey": true`.
    */
   fun getSymmetricKey(
-    derivationOptionsJson: String,
+    recipeJson: String,
     callback: Callback<SymmetricKey>? = null
   )
 
   /**
    * Get a [SigningKey] derived from the user's DiceKey (the seed) and the key-derivation options
-   * specified via [derivationOptionsJson],
+   * specified via [recipeJson],
    * in [Recipe JSON Format](https://dicekeys.github.io/seeded-crypto/recipe_format.html),
    * which must specify
    *  `"clientMayRetrieveKey": true`.
    */
   fun getSigningKey(
-    derivationOptionsJson: String,
+    recipeJson: String,
     callback: Callback<SigningKey>? = null
   )
 
 
   /**
-   * Get a [SealingKey] derived from the user's DiceKey and the [ApiDerivationOptions] specified
+   * Get a [SealingKey] derived from the user's DiceKey and the [ApiRecipe] specified
    * in [Recipe JSON Format](https://dicekeys.github.io/seeded-crypto/recipe_format.html)
-   * as [derivationOptionsJson].
+   * as [recipeJson].
    */
   fun getSealingKey(
-    derivationOptionsJson: String,
+    recipeJson: String,
     callback: Callback<SealingKey>? = null
   )
 
@@ -86,14 +86,14 @@ interface CallbackApi {
   /**
    * Seal (encrypt with a message-authentication code) a message ([plaintext]) with a
    * symmetric key derived from the user's DiceKey, the
-   * [derivationOptionsJson]
+   * [recipeJson]
    * in [Recipe JSON Format](https://dicekeys.github.io/seeded-crypto/recipe_format.html),
    * and [UnsealingInstructions] specified via a JSON string as
    * [unsealingInstructions] in the
    * in [Post-Decryption Instructions JSON Format](https://dicekeys.github.io/seeded-crypto/unsealing_instructions_format.html).
    */
   fun sealWithSymmetricKey(
-    derivationOptionsJson: String,
+    recipeJson: String,
     plaintext: ByteArray,
     unsealingInstructions: String = "",
     callback: Callback<PackagedSealedMessage>
@@ -103,7 +103,7 @@ interface CallbackApi {
   /**
    * Unseal (decrypt & authenticate) a [packagedSealedMessage] that was previously sealed with a
    * symmetric key derived from the user's DiceKey, the
-   * [ApiDerivationOptions] specified in JSON format via [PackagedSealedMessage.derivationOptionsJson],
+   * [ApiRecipe] specified in JSON format via [PackagedSealedMessage.recipeJson],
    * and any [UnsealingInstructions] optionally specified by [PackagedSealedMessage.unsealingInstructions]
    * in [Post-Decryption Instructions JSON Format](https://dicekeys.github.io/seeded-crypto/unsealing_instructions_format.html).
    *
@@ -118,20 +118,20 @@ interface CallbackApi {
 
   /**
    * Get a public [SignatureVerificationKey] derived from the user's DiceKey and the
-   * [ApiDerivationOptions] specified in JSON format via [derivationOptionsJson]
+   * [ApiRecipe] specified in JSON format via [recipeJson]
    */
   fun getSignatureVerificationKey(
-    derivationOptionsJson: String,
+    recipeJson: String,
     callback: Callback<SignatureVerificationKey>? = null
   )
 
   /**
    * Sign a [message] using a public/private signing key pair derived
-   * from the user's DiceKey and the [ApiDerivationOptions] specified in JSON format via
-   * [derivationOptionsJson].
+   * from the user's DiceKey and the [ApiRecipe] specified in JSON format via
+   * [recipeJson].
    */
   fun generateSignature(
-    derivationOptionsJson: String,
+    recipeJson: String,
     message: ByteArray,
     callback: Callback<GenerateSignatureResult>? = null
   )

--- a/api/src/main/java/org/dicekeys/api/DerivationRecipe.kt
+++ b/api/src/main/java/org/dicekeys/api/DerivationRecipe.kt
@@ -32,13 +32,13 @@ fun addSequenceNumberToDerivationOptionsJson(derivationOptionsWithoutSequenceNum
 }
 
 private fun augmentRecipeJson(template: DerivationRecipe, sequenceNumber: Int, lengthInChars: Int): String {
-    var derivationOptionsJson = template.derivationOptionsJson
+    var recipeJson = template.recipeJson
     if (template.type == DerivationOptions.Type.Password && lengthInChars > 0) {
-        derivationOptionsJson = addLengthInCharsToDerivationOptionsJson(derivationOptionsJson, lengthInChars)
+        recipeJson = addLengthInCharsToDerivationOptionsJson(recipeJson, lengthInChars)
     }
-    derivationOptionsJson =
-            addSequenceNumberToDerivationOptionsJson(derivationOptionsJson, sequenceNumber)
-    return derivationOptionsJson
+    recipeJson =
+            addSequenceNumberToDerivationOptionsJson(recipeJson, sequenceNumber)
+    return recipeJson
 }
 
 @Serializable
@@ -49,7 +49,7 @@ data class DerivationRecipe(
         @SerialName("name")
         val name: String,
         @SerialName("derivation_options_json")
-        val derivationOptionsJson: String
+        val recipeJson: String
 ) : Parcelable {
 
     constructor(template: DerivationRecipe, sequenceNumber: Int, lengthInChars: Int = 0):
@@ -69,14 +69,14 @@ data class DerivationRecipe(
 
     @IgnoredOnParcel
     val sequence by lazy {
-        Json.parseToJsonElement(derivationOptionsJson).jsonObject["#"]?.jsonPrimitive?.int ?: 1
+        Json.parseToJsonElement(recipeJson).jsonObject["#"]?.jsonPrimitive?.int ?: 1
     }
 
     /*
      * An easy way to have a unique identifier for this Recipe
      */
     val id
-        get() = derivationOptionsJson.hashCode().toString()
+        get() = recipeJson.hashCode().toString()
 
     override fun toString(): String = Json.encodeToString(this)
 }

--- a/api/src/main/java/org/dicekeys/api/DerivationRecipeTemplates.kt
+++ b/api/src/main/java/org/dicekeys/api/DerivationRecipeTemplates.kt
@@ -7,7 +7,7 @@ package org.dicekeys.api
 //  Tue, 02 Feb 2021 22:48:52 GMT
 //
 //  These templates are hard coded because the recipe (also known as
-//  derivationOptionsJson) is an input to the hash function used to derive
+//  recipeJson) is an input to the hash function used to derive
 //  passwords and other secrets, and so even a single-character change
 //  to the recipe will change the entire contents of the password/secret.
 //

--- a/api/src/main/java/org/dicekeys/api/Exceptions.kt
+++ b/api/src/main/java/org/dicekeys/api/Exceptions.kt
@@ -4,7 +4,7 @@ import java.lang.IllegalArgumentException
 
 
 /**
- * Thrown when a key to be derived has requirements in derivationOptionsJson that disallow
+ * Thrown when a key to be derived has requirements in recipeJson that disallow
  * the calling client application from accessing or using the key.
  */
 class ClientPackageNotAuthorizedException(

--- a/api/src/main/java/org/dicekeys/api/SuspendApi.kt
+++ b/api/src/main/java/org/dicekeys/api/SuspendApi.kt
@@ -5,36 +5,36 @@ import org.dicekeys.crypto.seeded.*
 interface SuspendApi {
 
   suspend fun generateSignature(
-    derivationOptionsJson: String,
+    recipeJson: String,
     message: ByteArray
   ): GenerateSignatureResult
 
   suspend fun getSealingKey(
-    derivationOptionsJson: String
+    recipeJson: String
   ): SealingKey
 
   suspend fun getSecret(
-    derivationOptionsJson: String
+    recipeJson: String
   ): Secret
 
   suspend fun getSignatureVerificationKey(
-    derivationOptionsJson: String
+    recipeJson: String
   ): SignatureVerificationKey
 
   suspend fun getSigningKey(
-    derivationOptionsJson: String
+    recipeJson: String
   ): SigningKey
 
   suspend fun getSymmetricKey(
-    derivationOptionsJson: String
+    recipeJson: String
   ): SymmetricKey
 
   suspend fun getUnsealingKey(
-    derivationOptionsJson: String
+    recipeJson: String
   ): UnsealingKey
 
   suspend fun sealWithSymmetricKey(
-    derivationOptionsJson: String,
+    recipeJson: String,
     plaintext: ByteArray,
     unsealingInstructions: String = ""
   ): PackagedSealedMessage

--- a/api/src/sample/ApiSamples.kt
+++ b/api/src/sample/ApiSamples.kt
@@ -37,15 +37,15 @@ class SampleActivity: AppCompatActivity() {
         try {
             // Derive keys that other application are forbidden from using.
             // (The DiceKeys app will refuse to (re)derive this key for other apps.)
-            val derivationOptionsJson = ApiDerivationOptions().apply {
-                restrictions = ApiDerivationOptions.Restrictions().apply {
+            val recipeJson = ApiRecipe().apply {
+                restrictions = ApiRecipe.Restrictions().apply {
                     // The activity's packageName field contains the name of this package
                     androidPackagePrefixesAllowed = listOf(packageName)
                 }
             }.toJson()
             // Get a public key derived form the user's DiceKey.
             // (Most apps will get this once and store it, rather than ask for it every time.)
-            val publicKey = diceKeysApiClient.getSealingkey(derivationOptionsJson)
+            val publicKey = diceKeysApiClient.getSealingkey(recipeJson)
             // With public key cryptoraphy, sealing a message does not require an API call
             // and is a fully synchronous operation (no waiting needed).
             val packagedSealedMessage = publicKey.seal("You call this a plaintext?")
@@ -68,16 +68,16 @@ class SampleActivity: AppCompatActivity() {
  */
 class ApiSamples {
 
-fun sampleOfApiDerivationOptions() {
-    val derivationOptionsJson: String =
-            ApiDerivationOptions.Symmetric().apply {
+fun sampleOfApiRecipe() {
+    val recipeJson: String =
+            ApiRecipe.Symmetric().apply {
                 // Ensure the JSON format has the "keyType" field specified
                 keyType = requiredKeyType  // sets "keyType": "Symmetric" since this class type is Symmetric
                 algorithm = defaultAlgorithm // sets "algorithm": "XSalsa20Poly1305"
                 // Set other fields in the spec in a Kotlin/Java friendly way
                 clientMayRetrieveKey = true // sets "clientMayRetrieveKey": true
                 // The restrictions subclass can be constructed
-                restrictions = ApiDerivationOptions.Restrictions().apply {
+                restrictions = ApiRecipe.Restrictions().apply {
                     androidPackagePrefixesAllowed = listOf("com.example.app")
                     urlPrefixesAllowed = listOf("https://example.com/app/")
                 }
@@ -89,8 +89,8 @@ fun sampleOfApiDerivationOptions() {
                 put("salt", "S0d1um Chl0r1d3")
             }.toJson()
     // Use this class to parse a JSON string specifying the derivation of a public/private key
-    if (ApiDerivationOptions.Public(derivationOptionsJson).clientMayRetrieveKey) {
-        // The derivationOptionsJson allows clients not just to use the derived key,
+    if (ApiRecipe.Public(recipeJson).clientMayRetrieveKey) {
+        // The recipeJson allows clients not just to use the derived key,
         // but also to retrieve a copy of it (conditional on evaluation of 'requirements')
     } // Converts DerivationOptions to JSON string format
 }

--- a/api/src/test/java/org/dicekeys/api/JsonSupportClassTests.kt
+++ b/api/src/test/java/org/dicekeys/api/JsonSupportClassTests.kt
@@ -33,14 +33,14 @@ class DerivationOptionsTests {
 
     @Test
     fun DerivationOptions_toAndBack() {
-        val kdo = ApiDerivationOptions.SymmetricKey().apply {
+        val kdo = ApiRecipe.SymmetricKey().apply {
             // Ensure the JSON format has the "keyType" field specified
             type = requiredType  // sets "keyType": "Symmetric" since this class type is Symmetric
             algorithm = defaultAlgorithm // sets "algorithm": "XSalsa20Poly1305"
             // Set other fields in the spec in a Kotlin/Java friendly way
             clientMayRetrieveKey = true // sets "clientMayRetrieveKey": true
             // The restrictions subclass can be constructed
-            restrictions = ApiDerivationOptions.Restrictions().apply {
+            restrictions = ApiRecipe.Restrictions().apply {
                 androidPackagePrefixesAllowed = listOf("com.example.app")
                 urlPrefixesAllowed = listOf("https://example.com/app/")
             }
@@ -51,8 +51,8 @@ class DerivationOptionsTests {
             // its original purpose
             put("salt", "S0d1um Chl0r1d3")
         }
-        val derivationOptionsJson = kdo.toJson()
-        val replica = ApiDerivationOptions(derivationOptionsJson)
+        val recipeJson = kdo.toJson()
+        val replica = ApiRecipe(recipeJson)
         assertTrue(compareJson(kdo, replica))
         val expectJson = """{
                 | "salt": "S0d1um Chl0r1d3",
@@ -82,15 +82,15 @@ class UnsealingInstructionsTests {
         val kdo = UnsealingInstructions().apply {
             // Ensure the JSON format has the "keyType" field specified
             // The restrictions subclass can be constructed
-            restrictions = ApiDerivationOptions.Restrictions().apply {
+            restrictions = ApiRecipe.Restrictions().apply {
                 androidPackagePrefixesAllowed = listOf("com.example.app")
                 urlPrefixesAllowed = listOf("https://example.com/app/", "https://evenworseexample.com")
             }
             userMustAcknowledgeThisMessage = "Only unseal this message if you are trying to " +
                 "reset your PoodleMail password."
         }
-        val derivationOptionsJson = kdo.toJson()
-        val replica = ApiDerivationOptions(derivationOptionsJson)
+        val recipeJson = kdo.toJson()
+        val replica = ApiRecipe(recipeJson)
         assertTrue(compareJson(kdo, replica))
         val expectJson = """{
             | "userMustAcknowledgeThisMessage": "Only unseal this message if you are trying to reset your PoodleMail password.",

--- a/app/src/main/java/org/dicekeys/app/viewmodels/RecipeViewModel.kt
+++ b/app/src/main/java/org/dicekeys/app/viewmodels/RecipeViewModel.kt
@@ -30,7 +30,7 @@ class RecipeViewModel @AssistedInject constructor(
 
     private fun generatePassword(){
         derivationRecipe.value?.let{ derivationRecipe ->
-            password.value = diceKey.toCanonicalRotation().let { Password.deriveFromSeed(it.toHumanReadableForm(), derivationRecipe.derivationOptionsJson).password }
+            password.value = diceKey.toCanonicalRotation().let { Password.deriveFromSeed(it.toHumanReadableForm(), derivationRecipe.recipeJson).password }
 
             updateSavedState()
         }

--- a/app/src/main/res/layout/recipe_fragment.xml
+++ b/app/src/main/res/layout/recipe_fragment.xml
@@ -144,7 +144,7 @@
                                 android:layout_height="wrap_content"
                                 android:layout_marginTop="5dp"
                                 tools:text="{allow : [this is the json]}"
-                                android:text="@{vm.derivationRecipe.derivationOptionsJson}"
+                                android:text="@{vm.derivationRecipe.recipeJson}"
                                 android:textColor="@android:color/background_dark"
                                 android:textSize="12sp" />
 

--- a/extra.md
+++ b/extra.md
@@ -13,7 +13,7 @@ to perform cryptographic operations using the derived keys,
 and to give those keys to your application if it is authorized to receive them.
 You specify how keys are derived and who can access them via the
 [Recipe JSON Format](https://dicekeys.github.io/seeded-crypto/recipe_format.html/),
-which you can construct and parse using the [ApiKeyDerivationOptions] class.
+which you can construct and parse using the [ApiRecipe] class.
 
 The API builds on the the cross-platform
 [Seeded Cryptography C++ Library](https://dicekeys.github.io/seeded-crypto/).
@@ -75,15 +75,15 @@ class SampleActivity: AppCompatActivity() {
         try {
             // Derive keys that other application are forbidden from using.
             // (The DiceKeys app will refuse to (re)derive this key for other apps.)
-            val keyDerivationOptionsJson = ApiKeyDerivationOptions().apply {
-                restrictions = ApiKeyDerivationOptions.Restrictions().apply {
+            val recipeJson = ApiRecipe().apply {
+                restrictions = ApiRecipe.Restrictions().apply {
                     // The activity's packageName field contains the name of this package
                     androidPackagePrefixesAllowed = listOf(packageName)
                 }
             }.toJson()
             // Get a public key derived form the user's DiceKey.
             // (Most apps will get this once and store it, rather than ask for it every time.)
-            val publicKey = diceKeysApiClient.getSealingKey(keyDerivationOptionsJson)
+            val publicKey = diceKeysApiClient.getSealingKey(recipeJson)
             // With public key cryptography, sealing a message does not require an API call
             // and is a fully synchronous operation (no waiting needed).
             val packagedSealedMessage = publicKey.seal("You call this a plaintext?")

--- a/fidowriter/src/main/java/com/dicekeys/fidowriter/MainActivity.kt
+++ b/fidowriter/src/main/java/com/dicekeys/fidowriter/MainActivity.kt
@@ -26,7 +26,7 @@ class MainActivity : AppCompatActivity() {
 
     private val INTENT_ACTION_USB_PERMISSION_EVENT = "org.dicekeys.intents.USB_PERMISSION_EVENT"
 
-    private val seedDerivationOptionsJson : String = """{
+    private val seedRecipe: String = """{
             |"hashFunction": "Argon2id",
             |"allow": [{"host": "fidowriter.dicekeys.com"}],
             |"androidPackagePrefixesAllowed":["com.dicekeys.fidowriter."]
@@ -71,7 +71,7 @@ class MainActivity : AppCompatActivity() {
         btn_generate_secret_from_dicekey.setOnClickListener {
             GlobalScope.launch(Dispatchers.Main) {
                 try {
-                    val seed = diceKeysApiClient.getSecret(seedDerivationOptionsJson)
+                    val seed = diceKeysApiClient.getSecret(seedRecipe)
                     edit_text_secret.text.clear()
                     edit_text_secret.text.insert(0, seed.secretBytes.joinToString(separator = "") { String.format("%02x", (it.toInt() and 0xFF)) })
                     render()

--- a/packages.md
+++ b/packages.md
@@ -31,7 +31,7 @@ This library can be used to derive keys from (hopefully strong) passwords or oth
 secret seeds.
 
 To this end, we have placed features specific to DiceKeys in the [org.dicekeys.api] namespace.
-That includes [ApiKeyDerivationOptions], which extends [KeyDerivationOptions] in this package
+That includes [ApiRecipe], which extends [Recipe] in this package
 with fields that would not apply to other seeded cryptography applications (e.g.,
 ignoring the orientation of the faces of dice within a DiceKey).
 It also includes the format for unsealing_instructions instructions [UnsealingInstructions]
@@ -46,7 +46,7 @@ This package uses and returns keys from the [org.dicekeys.crypto.seeded] package
 
 You specify how keys are derived, and place restrictions on their use, via the
 [Recipe JSON Format](https://dicekeys.github.io/seeded-crypto/recipe_format.html/),
-which you can construct and parse using [ApiKeyDerivationOptions].
+which you can construct and parse using [ApiRecipe].
 
 If you are sealing messages with a [SymmetricKey] or [PublicKey], you can
 instruct the DiceKeys to enforce additional restrictions before unsealing a

--- a/seeded/src/androidTest/java/org/dicekeys/crypto/seeded/SealingKeyTests.kt
+++ b/seeded/src/androidTest/java/org/dicekeys/crypto/seeded/SealingKeyTests.kt
@@ -29,15 +29,15 @@ class SealingKeyTests {
 
     @Test
     fun createPublicKeyFromJson() {
-        val derivationOptionsJson = """{}"""
+        val recipeJson = """{}"""
         val publicKeyJson = """{
             "keyBytes": "000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f",
-            "derivationOptionsJson": "$derivationOptionsJson"
+            "recipe": "$recipeJson"
         }"""
         val pk = SealingKey.fromJson(publicKeyJson)
         assertEquals(0x0f, pk.keyBytes[31].toInt())
-        assertEquals(derivationOptionsJson, pk.derivationOptionsJson)
-        val copyOfPk = SealingKey(pk.keyBytes, pk.derivationOptionsJson)
+        assertEquals(recipeJson, pk.recipeJson)
+        val copyOfPk = SealingKey(pk.keyBytes, pk.recipeJson)
         assertEquals(pk, copyOfPk)
     }
 
@@ -45,8 +45,8 @@ class SealingKeyTests {
 
     @Test
     fun testPrivateKeys() {
-        val derivationOptionsJson = """{"type": "UnsealingKey"}"""
-        val sk = UnsealingKey.deriveFromSeed(seed, derivationOptionsJson)
+        val recipeJson = """{"type": "UnsealingKey"}"""
+        val sk = UnsealingKey.deriveFromSeed(seed, recipeJson)
         val pk = sk.getSealingkey()
         val testMessage = "some message to test"
         val packagedSealedMessage = pk.seal( testMessage );
@@ -67,10 +67,10 @@ class SealingKeyTests {
 
     @Test
     fun shouldThrowInvalidDerivationOptionValueException() {
-        val derivationOptionsJson = """{}"""
+        val recipeJson = """{}"""
         val publicKeyJson = """{
             "ErrorInsteadOfKeyBytes": "000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f",
-            "derivationOptionsJson": "$derivationOptionsJson"
+            "recipe": "$recipeJson"
         }"""
         try {
             SealingKey.fromJson(publicKeyJson)
@@ -98,15 +98,15 @@ class SealingKeyTests {
 
     @Test
     fun createSignatureVerificationKeyFromJson() {
-        val derivationOptionsJson = """{}"""
+        val recipeJson = """{}"""
         val signatureVerificationKeyJson = """{
             "keyBytes": "000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f",
-            "derivationOptionsJson": "$derivationOptionsJson"
+            "recipe": "$recipeJson"
         }"""
         val svk = SignatureVerificationKey.fromJson(signatureVerificationKeyJson)
         assertEquals(0x0f, svk.keyBytes[31].toInt())
-        assertEquals(derivationOptionsJson, svk.derivationOptionsJson)
-        val copyOfSvk = SignatureVerificationKey(svk.keyBytes, svk.derivationOptionsJson)
+        assertEquals(recipeJson, svk.recipeJson)
+        val copyOfSvk = SignatureVerificationKey(svk.keyBytes, svk.recipeJson)
         assertEquals(svk, copyOfSvk)
 
         val bCopy = svk.toSerializedBinaryForm()
@@ -116,8 +116,8 @@ class SealingKeyTests {
 
     @Test
     fun testSigningAndVerificationPairs() {
-        val derivationOptionsJson = """{"type": "SigningKey"}"""
-        val sk = SigningKey.deriveFromSeed(seed, derivationOptionsJson)
+        val recipeJson = """{"type": "SigningKey"}"""
+        val sk = SigningKey.deriveFromSeed(seed, recipeJson)
         val vk = sk.getSignatureVerificationKey()
         val testMessage = "some message to test"
         val signature = sk.generateSignature( testMessage )
@@ -141,8 +141,8 @@ class SealingKeyTests {
 
     @Test
     fun testSymmetricKey() {
-        val derivationOptionsJson = """{"type": "SymmetricKey"}"""
-        val sk = SymmetricKey.deriveFromSeed(seed, derivationOptionsJson)
+        val recipeJson = """{"type": "SymmetricKey"}"""
+        val sk = SymmetricKey.deriveFromSeed(seed, recipeJson)
         val testMessage = "some message to test"
         val packagedSealedMessage = sk.seal(testMessage)
         val decryptedBytes = SymmetricKey.unseal(packagedSealedMessage, seed)
@@ -152,20 +152,20 @@ class SealingKeyTests {
         val binaryCopy = sk.toSerializedBinaryForm()
         val copy = SymmetricKey.fromSerializedBinaryForm(binaryCopy)
         assertArrayEquals(copy.keyBytes, sk.keyBytes)
-        assertEquals(copy.derivationOptionsJson, sk.derivationOptionsJson)
+        assertEquals(copy.recipeJson, sk.recipeJson)
 
     }
 
     @Test
     fun testSeed() {
-        val derivationOptionsJson = """{"type": "Secret", "lengthInBytes": 48}"""
-        val s = Secret.deriveFromSeed(seed, derivationOptionsJson)
+        val recipeJson = """{"type": "Secret", "lengthInBytes": 48}"""
+        val s = Secret.deriveFromSeed(seed, recipeJson)
         assertEquals(s.secretBytes.size, 48)
 
         val binaryCopy = s.toSerializedBinaryForm()
         val copy = Secret.fromSerializedBinaryForm(binaryCopy)
         assertArrayEquals(copy.secretBytes, s.secretBytes)
-        assertEquals(copy.derivationOptionsJson, s.derivationOptionsJson)
+        assertEquals(copy.recipeJson, s.recipeJson)
     }
 
 

--- a/seeded/src/main/java/org/dicekeys/crypto/seeded/DerivationOptions.kt
+++ b/seeded/src/main/java/org/dicekeys/crypto/seeded/DerivationOptions.kt
@@ -3,10 +3,10 @@ import org.json.JSONObject
 
 
 /**
- * A class to parse and construct key-derivation options in _derivationOptionsJson_ format.
+ * A class to parse and construct key-derivation options in _recipeJson_ format.
  *
  * ```
- * val derivationOptionsJson: String =
+ * val recipeJson: String =
  *   DerivationOptions.Symmetric().apply {
  *       // Ensure the JSON format has the "keyType" field specified
  *       keyType = requiredKeyType  // sets "keyType": "Symmetric" since this class type is Symmetric
@@ -33,12 +33,12 @@ import org.json.JSONObject
  *  adding virtual fields and the types used to support them.
  */
 open class DerivationOptions(
-    derivationOptionsJson: String? = null,
+    recipeJson: String? = null,
     val requiredType: Type? = null
 ): JSONObject(
-    if (derivationOptionsJson == null || derivationOptionsJson.isEmpty())
+    if (recipeJson == null || recipeJson.isEmpty())
         "{}"
-    else derivationOptionsJson
+    else recipeJson
 ) {
     /**
      * The keyType values currently supported by this library as an enum,
@@ -199,12 +199,12 @@ open class DerivationOptions(
      * spec allows fields to be placed in different orders.
      * Any change will yield a different key.
      * Rather, the original JSON string should be preserved.
-     * This library is designed to preserve the derivationOptionsJson string for you.
+     * This library is designed to preserve the recipeJson string for you.
      * All derived keys, including the public [SealingKey] and [SignatureVerificationKey], contain
-     * the derivationOptionsJson used to derive them so that the corresponding
+     * the recipeJson used to derive them so that the corresponding
      * [UnsealingKey] and [SigningKey] can be re-derived if needed.
      * All values sealed by a [SymmetricKey] or [PublicKe] are returned in a
-     * [PackagedSealedMessage] class which contains the derivationOptionsJson needed
+     * [PackagedSealedMessage] class which contains the recipeJson needed
      * to re-derive the keys to unseal the message (but not the seed, as that would
      * allow anyone who intercepts the message to re-derive the key.)
      */
@@ -220,19 +220,19 @@ open class DerivationOptions(
         }}
     }
 
-    class UnsealingKey(derivationOptionsJson: String? = null) :
-        DerivationOptions(derivationOptionsJson,  Type.UnsealingKey)
+    class UnsealingKey(recipeJson: String? = null) :
+        DerivationOptions(recipeJson,  Type.UnsealingKey)
 
-    class Password(derivationOptionsJson: String? = null) :
-      DerivationOptions(derivationOptionsJson,  Type.Password)
+    class Password(recipeJson: String? = null) :
+      DerivationOptions(recipeJson,  Type.Password)
 
-    class Secret(derivationOptionsJson: String? = null) :
-        DerivationOptions(derivationOptionsJson,  Type.Secret)
+    class Secret(recipeJson: String? = null) :
+        DerivationOptions(recipeJson,  Type.Secret)
 
-    class SigningKey(derivationOptionsJson: String? = null) :
-        DerivationOptions(derivationOptionsJson,  Type.SigningKey)
+    class SigningKey(recipeJson: String? = null) :
+        DerivationOptions(recipeJson,  Type.SigningKey)
 
-    class SymmetricKey(derivationOptionsJson: String? = null) :
-        DerivationOptions(derivationOptionsJson,  Type.SymmetricKey)
+    class SymmetricKey(recipeJson: String? = null) :
+        DerivationOptions(recipeJson,  Type.SymmetricKey)
 
 }

--- a/seeded/src/main/java/org/dicekeys/crypto/seeded/Exceptions.kt
+++ b/seeded/src/main/java/org/dicekeys/crypto/seeded/Exceptions.kt
@@ -11,14 +11,14 @@ class ClientNotAuthorizedException(message: String) : java.lang.Exception(messag
 class CryptographicVerificationFailureException(message: String) : java.lang.Exception(message)
 
 /**
- * Thrown when a derivationOptionsJson parameter contains a string that is neither
+ * Thrown when a recipeJson parameter contains a string that is neither
  * empty nor in valid JSON format.
  */
 class InvalidDerivationOptionsJsonException(message: String?) : java.lang.Exception(
         message ?: "Invalid key-derivation options specified")
 
 /**
- * Thrown when a derivationOptionsJson parameter contains a field that has an invalid
+ * Thrown when a recipeJson parameter contains a field that has an invalid
  * or forbidden value.
  */
 class InvalidDerivationOptionValueException(message: String) : java.lang.Exception(message)
@@ -35,6 +35,6 @@ class InvalidArgumentException(message: String) : java.lang.Exception(message)
 class JsonParsingException(message: String) : java.lang.Exception(message)
 
 /**
- * Thrown when derivationOptionsJson parameter contains an invalid lengthInBytes field.
+ * Thrown when recipeJson parameter contains an invalid lengthInBytes field.
  */
 class KeyLengthException(message: String) : java.lang.Exception(message)

--- a/seeded/src/main/java/org/dicekeys/crypto/seeded/PackagedSealedMessage.kt
+++ b/seeded/src/main/java/org/dicekeys/crypto/seeded/PackagedSealedMessage.kt
@@ -61,7 +61,7 @@ class PackagedSealedMessage internal constructor(
 
     /**
      * Serialize the object to a JSON format that stores the [ciphertext],
-     * [derivationOptionsJson], and [unsealingInstructions].
+     * [recipeJson], and [unsealingInstructions].
      * It can then be reconstructed via a call to [fromJson].
      */
     external override fun toJson(): String

--- a/seeded/src/test/java/org/dicekeys/crypto/seeded/ExampleUnitTest.kt
+++ b/seeded/src/test/java/org/dicekeys/crypto/seeded/ExampleUnitTest.kt
@@ -19,7 +19,7 @@ class ExampleUnitTest {
 //fun createPublicKeyFromJson() {
 //    val pk = PublicKey("""{
 //            "keyBytes": "000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f",
-//            "derivationOptionsJson": "{}"
+//            "recipe": "{}"
 //        }""")
 //    assertEquals(0x0f, pk.keyBytes[31].toInt())
 //}

--- a/testapp/src/main/java/org/dicekeys/testapp/MainActivity.kt
+++ b/testapp/src/main/java/org/dicekeys/testapp/MainActivity.kt
@@ -21,7 +21,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var buttonStart: Button
     private lateinit var resultTextView: TextView
     private lateinit var api : DiceKeysWebApiClient
-    val derivationOptionsJson = "{}"
+    val recipeJson = "{}"
     val testMessage = "The secret ingredient is dihydrogen monoxide"
     val testMessageByteArray = testMessage.toByteArray(Charsets.UTF_8)
 
@@ -39,25 +39,25 @@ class MainActivity : AppCompatActivity() {
         buttonStart = findViewById(R.id.btn_start)
 
         buttonStart.setOnClickListener{ GlobalScope.launch(Dispatchers.Main) { try {
-            val seed = api.getSecret(derivationOptionsJson)
+            val seed = api.getSecret(recipeJson)
             resultTextView.text = "Seed=${Base64.encodeToString(seed.secretBytes, Base64.DEFAULT)}"
             val packagedSealedMessage = api.sealWithSymmetricKey(
-                derivationOptionsJson,
+                recipeJson,
                 testMessageByteArray
             )
             resultTextView.text = "${resultTextView.text}\nSymmetrically sealed message '${testMessage}' as ciphertext '${Base64.encodeToString(packagedSealedMessage.ciphertext, Base64.DEFAULT)}'"
             val plaintext = api.unsealWithSymmetricKey(packagedSealedMessage)
             resultTextView.text =
                 "${resultTextView.text}\nUnsealed '${String(plaintext, Charsets.UTF_8)}'"
-            val sig = api.generateSignature(derivationOptionsJson, testMessageByteArray)
+            val sig = api.generateSignature(recipeJson, testMessageByteArray)
             resultTextView.text =
                 "${resultTextView.text}\nSigned test message '${Base64.encodeToString(sig.signature, Base64.DEFAULT)}'"
-            val signatureVerificationKey = api.getSignatureVerificationKey(derivationOptionsJson)
+            val signatureVerificationKey = api.getSignatureVerificationKey(recipeJson)
             val keysMatch = signatureVerificationKey == sig.signatureVerificationKey
             val verified = signatureVerificationKey.verifySignature(testMessageByteArray, sig.signature)
             resultTextView.text =
                 "${resultTextView.text}\nVerification key match=${keysMatch}, verification result=${verified}"
-            val publicKey = api.getSealingKey(derivationOptionsJson)
+            val publicKey = api.getSealingKey(recipeJson)
             val packagedSealedPkMessage = publicKey.seal(testMessageByteArray, """{
                |  "requireUsersConsent": {
                |     "question": "Do you want use \"8fsd8pweDmqed\" as your SpoonerMail account password and remove your current password?",

--- a/trustedapp/src/androidTest/java/org/dicekeys/trustedapp/ApiPermissionChecksInstrumentedTest.kt
+++ b/trustedapp/src/androidTest/java/org/dicekeys/trustedapp/ApiPermissionChecksInstrumentedTest.kt
@@ -2,7 +2,7 @@ package org.dicekeys.trustedapp
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CompletableDeferred
-import org.dicekeys.api.ApiDerivationOptions
+import org.dicekeys.api.ApiRecipe
 import org.dicekeys.api.ClientPackageNotAuthorizedException
 import org.dicekeys.api.UnsealingInstructions
 import org.dicekeys.trustedapp.apicommands.permissionchecked.ApiPermissionChecksForPackages
@@ -28,28 +28,28 @@ class ApiPermissionChecksInstrumentedTest {
 
     Assert.assertTrue(ApiPermissionChecksForPackages("com.example"){ deferredAllow }
       .doesClientMeetAuthenticationRequirements(
-        ApiDerivationOptions().apply {
+        ApiRecipe().apply {
           allowAndroidPrefixes = listOf("com.example", "com.other")
         }
       ))
 
     Assert.assertTrue(ApiPermissionChecksForPackages("com.example"){ deferredAllow }
       .doesClientMeetAuthenticationRequirements(
-        ApiDerivationOptions().apply {
+        ApiRecipe().apply {
           allowAndroidPrefixes = listOf("com.example.", "com.other")
         }
       ))
 
       Assert.assertTrue(ApiPermissionChecksForPackages("com.example."){ deferredAllow }
       .doesClientMeetAuthenticationRequirements(
-        ApiDerivationOptions().apply {
+        ApiRecipe().apply {
           allowAndroidPrefixes = listOf("com.example", "com.other")
         }
       ))
 
       Assert.assertFalse(ApiPermissionChecksForPackages("com.examplespoof"){ deferredAllow }
       .doesClientMeetAuthenticationRequirements(
-        ApiDerivationOptions().apply {
+        ApiRecipe().apply {
           allowAndroidPrefixes = listOf("com.example", "com.other")
         }
       ))
@@ -60,7 +60,7 @@ class ApiPermissionChecksInstrumentedTest {
   fun preventsLengthExtensionAttack() {
     ApiPermissionChecksForPackages("com.examplespoof"){ deferredAllow }
       .throwIfClientNotAuthorized(
-        ApiDerivationOptions().apply {
+        ApiRecipe().apply {
           allowAndroidPrefixes = listOf("com.example", "com.other")
         }
       )
@@ -70,7 +70,7 @@ class ApiPermissionChecksInstrumentedTest {
   fun throwsIfAndroidPackagePrefixesNotSet() {
     ApiPermissionChecksForPackages("com.example"){ deferredAllow }
       .throwIfClientNotAuthorized(
-        ApiDerivationOptions().apply{
+        ApiRecipe().apply{
           allowAndroidPrefixes =listOf("https://someplaceotherthanhere.com/")
         }
       )

--- a/trustedapp/src/androidTest/java/org/dicekeys/trustedapp/EndToEndUrlApiTests.kt
+++ b/trustedapp/src/androidTest/java/org/dicekeys/trustedapp/EndToEndUrlApiTests.kt
@@ -48,7 +48,7 @@ class EndToEndUrlApiTests {
     return mockedWebApi!!
   }
 
-  private val derivationOptionsJson = "{ \"allow\": [{\"host\": \"my.app\"}] }"
+  private val recipeJson = "{ \"allow\": [{\"host\": \"my.app\"}] }"
   private val testMessage = "The secret ingredient is dihydrogen monoxide"
   private val testMessageByteArray = testMessage.toByteArray(Charsets.UTF_8)
 
@@ -58,7 +58,7 @@ class EndToEndUrlApiTests {
 
     runBlocking {
       val packagedSealedMessage = api.sealWithSymmetricKey(
-        derivationOptionsJson,
+        recipeJson,
         testMessageByteArray
       )
       val plaintext = api.unsealWithSymmetricKey(packagedSealedMessage)
@@ -68,8 +68,8 @@ class EndToEndUrlApiTests {
 
   @Test
   fun signAndVerify() { runBlocking {
-    val sig = api.generateSignature(derivationOptionsJson, testMessageByteArray)
-    val signatureVerificationKey = api.getSignatureVerificationKey(derivationOptionsJson)
+    val sig = api.generateSignature(recipeJson, testMessageByteArray)
+    val signatureVerificationKey = api.getSignatureVerificationKey(recipeJson)
     Assert.assertArrayEquals(signatureVerificationKey.keyBytes, sig.signatureVerificationKey.keyBytes)
     Assert.assertTrue(signatureVerificationKey.verifySignature(testMessageByteArray, sig.signature))
     Assert.assertFalse(signatureVerificationKey.verifySignature(ByteArray(0), sig.signature))
@@ -85,7 +85,7 @@ class EndToEndUrlApiTests {
 
   @Test
   fun getSecretWithHandshake() { runBlocking {
-    val derivationOptions = ApiDerivationOptions().apply {
+    val derivationOptions = ApiRecipe().apply {
       requireAuthenticationHandshake = true
       allow = listOf(WebBasedApplicationIdentity("my.app", null))
       lengthInBytes = 13

--- a/trustedapp/src/androidTest/java/org/dicekeys/trustedapp/PermissionCheckedCommandsInstrumentedTest.kt
+++ b/trustedapp/src/androidTest/java/org/dicekeys/trustedapp/PermissionCheckedCommandsInstrumentedTest.kt
@@ -3,7 +3,7 @@ package org.dicekeys.trustedapp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
-import org.dicekeys.api.ApiDerivationOptions
+import org.dicekeys.api.ApiRecipe
 import org.dicekeys.api.ClientMayNotRetrieveKeyException
 import org.dicekeys.api.ClientPackageNotAuthorizedException
 import org.dicekeys.api.UnsealingInstructions
@@ -38,7 +38,7 @@ class PermissionCheckedCommandsInstrumentedTest {
         ) })
       { CompletableDeferred(diceKey) })
         .sealWithSymmetricKey(
-          ApiDerivationOptions().apply {
+          ApiRecipe().apply {
             allowAndroidPrefixes = listOf("com.example")
           }.toJson(),
           "The secret ingredient is sarcasm.".toByteArray(),
@@ -58,7 +58,7 @@ class PermissionCheckedCommandsInstrumentedTest {
       { CompletableDeferred(diceKey) })
         .unsealWithSymmetricKey(PackagedSealedMessage(
           ByteArray(0),
-          ApiDerivationOptions().apply {
+          ApiRecipe().apply {
             allowAndroidPrefixes = listOf("com.example")
           }.toJson(),
           UnsealingInstructions().toJson()
@@ -110,7 +110,7 @@ class PermissionCheckedCommandsInstrumentedTest {
         ) })
       { CompletableDeferred(diceKey) })
       val privateKey = api.getUnsealingKey(
-        ApiDerivationOptions().apply {
+        ApiRecipe().apply {
           clientMayRetrieveKey = true
           allowAndroidPrefixes = listOf("com.example")
         }.toJson()

--- a/trustedapp/src/main/java/org/dicekeys/trustedapp/activities/DiceKeyWithDerivedValue.kt
+++ b/trustedapp/src/main/java/org/dicekeys/trustedapp/activities/DiceKeyWithDerivedValue.kt
@@ -37,8 +37,8 @@ class DiceKeyWithDerivedValue : AppCompatActivity() {
         derivationRecipe.value=derivationRecipeTemplates.get(intent.getIntExtra("derivationRecipeTemplateIndex",0))
 
         binding.tvRecipeFor.text= String.format(getString(R.string.recipe_for_password, this.derivationRecipe.value!!.name))
-        binding.tvRecipeJson.text= derivationRecipe.value!!.derivationOptionsJson
-        binding.tvPassword.text= DiceKeyState.diceKey?.toCanonicalRotation()?.let { Password.deriveFromSeed(it.toHumanReadableForm(), derivationRecipe.value!!.derivationOptionsJson,"").password }
+        binding.tvRecipeJson.text= derivationRecipe.value!!.recipeJson
+        binding.tvPassword.text= DiceKeyState.diceKey?.toCanonicalRotation()?.let { Password.deriveFromSeed(it.toHumanReadableForm(), derivationRecipe.value!!.recipeJson,"").password }
         binding.btnDown.setOnClickListener {sequencUpDown(false)}
         binding.btnUp.setOnClickListener {sequencUpDown(true)}
         binding.btnCopyPassword.setOnClickListener{copyPassword()}
@@ -48,10 +48,10 @@ class DiceKeyWithDerivedValue : AppCompatActivity() {
             derivationRecipe.value = DerivationRecipe(derivationRecipeTemplates.get(intent.getIntExtra("derivationRecipeTemplateIndex", 0)), intValue )
         })
 
-        /*Observer derivation recipe change and update password, derivationOptionsJson */
+        /*Observer derivation recipe change and update password, recipeJson */
         derivationRecipe.observe(this, Observer {value ->
-            binding.tvPassword.text=DiceKeyState.diceKey?.toCanonicalRotation()?.let { Password.deriveFromSeed(it.toHumanReadableForm(),value.derivationOptionsJson).password }
-            binding.tvRecipeJson.text=value.derivationOptionsJson
+            binding.tvPassword.text=DiceKeyState.diceKey?.toCanonicalRotation()?.let { Password.deriveFromSeed(it.toHumanReadableForm(),value.recipeJson).password }
+            binding.tvRecipeJson.text=value.recipeJson
         })
 
         /*Sequence number text change event*/

--- a/trustedapp/src/main/java/org/dicekeys/trustedapp/apicommands/permissionchecked/ApiPermissionChecks.kt
+++ b/trustedapp/src/main/java/org/dicekeys/trustedapp/apicommands/permissionchecked/ApiPermissionChecks.kt
@@ -1,7 +1,7 @@
 package org.dicekeys.trustedapp.apicommands.permissionchecked
 
 import kotlinx.coroutines.Deferred
-import org.dicekeys.api.ApiDerivationOptions
+import org.dicekeys.api.ApiRecipe
 import org.dicekeys.api.AuthenticationRequirements
 import org.dicekeys.api.ClientMayNotRetrieveKeyException
 import org.dicekeys.api.UnsealingInstructions
@@ -41,7 +41,7 @@ abstract class ApiPermissionChecks(
    * @throws ClientNotAuthorizedException
    */
 //  fun throwIfClientNotAuthorized(
-//    derivationOptions: ApiDerivationOptions
+//    derivationOptions: ApiRecipe
 //  ): Unit = throwIfClientNotAuthorized(derivationOptions)
 
 

--- a/trustedapp/src/main/java/org/dicekeys/trustedapp/apicommands/permissionchecked/ApiPermissionChecksForUrls.kt
+++ b/trustedapp/src/main/java/org/dicekeys/trustedapp/apicommands/permissionchecked/ApiPermissionChecksForUrls.kt
@@ -21,7 +21,7 @@ open class ApiPermissionChecksForUrls(
   private fun doesPathMatchRequirement(pathExpectedSlashOptional: String, pathObserved: String): Boolean {
     // Paths must start with a "/".  If the path requirement didn't start with a "/",
     // we'll insert one assuming this was a mistake by the developer of the client software
-    // that created the derivationOptionsJson string.
+    // that created the recipeJson string.
     val pathExpected = if (pathExpectedSlashOptional.isEmpty() || pathExpectedSlashOptional[0] == '/')
       pathExpectedSlashOptional else "/$pathExpectedSlashOptional"
 

--- a/trustedapp/src/main/java/org/dicekeys/trustedapp/apicommands/permissionchecked/PermissionCheckedCommands.kt
+++ b/trustedapp/src/main/java/org/dicekeys/trustedapp/apicommands/permissionchecked/PermissionCheckedCommands.kt
@@ -25,31 +25,31 @@ class PermissionCheckedCommands(
   /**
    * Implement [DiceKeysIntentApiClient.getSecret] with the necessary permissions checks
    */
-  suspend fun getSecret(derivationOptionsJson: String): Secret =
+  suspend fun getSecret(recipeJson: String): Secret =
     Secret.deriveFromSeed(
       permissionCheckedSeedAccessor.getSeedOrThrowIfClientNotAuthorized(
-        derivationOptionsJson,
+        recipeJson,
         DerivationOptions.Type.Secret,
         ApiStrings.Commands.getSecret
       ),
-      derivationOptionsJson
+      recipeJson
     )
 
   /**
    * Implement [DiceKeysIntentApiClient.sealWithSymmetricKey] with the necessary permissions checks
    */
   suspend fun sealWithSymmetricKey(
-    derivationOptionsJson: String,
+    recipeJson: String,
     plaintext: ByteArray,
     unsealingInstructions: String?
   ): PackagedSealedMessage =
     SymmetricKey.deriveFromSeed(
       permissionCheckedSeedAccessor.getSeedOrThrowIfClientNotAuthorized(
-        derivationOptionsJson,
+        recipeJson,
         DerivationOptions.Type.SymmetricKey,
         ApiStrings.Commands.sealWithSymmetricKey
       ),
-      derivationOptionsJson
+      recipeJson
     ).seal(plaintext, unsealingInstructions ?: "")
 
   /**
@@ -70,69 +70,69 @@ class PermissionCheckedCommands(
    * Implement [DiceKeysIntentApiClient.getSealingKey] with the necessary permissions checks
    */
   suspend fun getSealingKey(
-    derivationOptionsJson: String
+    recipeJson: String
   ) : SealingKey =
     UnsealingKey.deriveFromSeed(
       permissionCheckedSeedAccessor.getSeedOrThrowIfClientNotAuthorized(
-        derivationOptionsJson,
+        recipeJson,
         DerivationOptions.Type.UnsealingKey,
         ApiStrings.Commands.getSealingKey
       ),
-      derivationOptionsJson
+      recipeJson
     ).getSealingkey()
 
   /**
    * Implement [DiceKeysIntentApiClient.getUnsealingKey] with the necessary permissions checks
    */
   suspend fun getUnsealingKey(
-    derivationOptionsJson: String
+    recipeJson: String
   ) : UnsealingKey = UnsealingKey.deriveFromSeed(
     permissionCheckedSeedAccessor.getSeedOrThrowIfClientsMayNotRetrieveKeysOrThisClientNotAuthorized(
-      derivationOptionsJson,
+      recipeJson,
       DerivationOptions.Type.UnsealingKey
     ),
-    derivationOptionsJson
+    recipeJson
   )
 
   /**
    * Implement [DiceKeysIntentApiClient.getSigningKey] with the necessary permissions checks
    */
   suspend fun getSigningKey(
-    derivationOptionsJson: String
+    recipeJson: String
   ) : SigningKey = SigningKey.deriveFromSeed(
     permissionCheckedSeedAccessor.getSeedOrThrowIfClientsMayNotRetrieveKeysOrThisClientNotAuthorized(
-      derivationOptionsJson,
+      recipeJson,
       DerivationOptions.Type.SigningKey
     ),
-    derivationOptionsJson
+    recipeJson
   )
 
   /**
    * Implement [DiceKeysIntentApiClient.getSymmetricKey] with the necessary permissions checks
    */
   suspend fun getSymmetricKey(
-    derivationOptionsJson: String
+    recipeJson: String
   ) : SymmetricKey = SymmetricKey.deriveFromSeed(
     permissionCheckedSeedAccessor.getSeedOrThrowIfClientsMayNotRetrieveKeysOrThisClientNotAuthorized(
-      derivationOptionsJson,
+      recipeJson,
       DerivationOptions.Type.SymmetricKey
     ),
-    derivationOptionsJson
+    recipeJson
   )
 
   /**
    * Implement [DiceKeysIntentApiClient.getSignatureVerificationKey] with the necessary permissions checks
    */
   suspend fun getSignatureVerificationKey(
-    derivationOptionsJson: String
+    recipeJson: String
   ) : SignatureVerificationKey =
     SigningKey.deriveFromSeed(
       permissionCheckedSeedAccessor.getSeedOrThrowIfClientNotAuthorized(
-        derivationOptionsJson,
+        recipeJson,
         DerivationOptions.Type.SigningKey,
         ApiStrings.Commands.getSignatureVerificationKey
       ),
-      derivationOptionsJson
+      recipeJson
     ).getSignatureVerificationKey()
 
   /**
@@ -154,15 +154,15 @@ class PermissionCheckedCommands(
    * Implement [DiceKeysIntentApiClient.generateSignature] with the necessary permissions checks
    */
   suspend fun generateSignature(
-    derivationOptionsJson: String,
+    recipeJson: String,
     message: ByteArray
   ): Pair<ByteArray, SignatureVerificationKey> = SigningKey.deriveFromSeed(
     permissionCheckedSeedAccessor.getSeedOrThrowIfClientNotAuthorized(
-        derivationOptionsJson,
+        recipeJson,
         DerivationOptions.Type.SigningKey,
         ApiStrings.Commands.generateSignature
       ),
-      derivationOptionsJson
+      recipeJson
     ).let{ signingKey ->
       Pair(signingKey.generateSignature(message), signingKey.getSignatureVerificationKey())
     }

--- a/trustedapp/src/main/java/org/dicekeys/trustedapp/apicommands/permissionchecked/PermissionCheckedMarshalledCommands.kt
+++ b/trustedapp/src/main/java/org/dicekeys/trustedapp/apicommands/permissionchecked/PermissionCheckedMarshalledCommands.kt
@@ -42,7 +42,7 @@ abstract class PermissionCheckedMarshalledCommands(
   abstract fun sendException(exception: Throwable)
 
   private fun getCommonDerivationOptionsJsonParameter() : String =
-    unmarshallRequiredStringParameter((Inputs.getSecret.derivationOptionsJson))
+    unmarshallRequiredStringParameter((Inputs.getSecret.recipeJson))
 
   private fun getAuthToken(): Unit = marshallResult(
     ApiStrings.UrlMetaInputs.authToken,

--- a/trustedapp/src/main/java/org/dicekeys/trustedapp/apicommands/permissionchecked/PermissionCheckedSeedAccessor.kt
+++ b/trustedapp/src/main/java/org/dicekeys/trustedapp/apicommands/permissionchecked/PermissionCheckedSeedAccessor.kt
@@ -2,7 +2,7 @@ package org.dicekeys.trustedapp.apicommands.permissionchecked
 
 import android.app.Activity
 import kotlinx.coroutines.Deferred
-import org.dicekeys.api.ApiDerivationOptions
+import org.dicekeys.api.ApiRecipe
 import org.dicekeys.api.ApiStrings
 import org.dicekeys.api.ClientMayNotRetrieveKeyException
 import org.dicekeys.api.UnsealingInstructions
@@ -70,7 +70,7 @@ open class PermissionCheckedSeedAccessor(
 
 
   private suspend fun getSeedOrThrowIfClientNotAuthorized(
-    derivationOptions: ApiDerivationOptions,
+    derivationOptions: ApiRecipe,
   ): String {
     permissionChecks.throwIfClientNotAuthorized(derivationOptions)
     return getDiceKey().toKeySeed(derivationOptions.excludeOrientationOfFaces)
@@ -78,18 +78,18 @@ open class PermissionCheckedSeedAccessor(
 
   /**
    * Request a seed generated from the user's DiceKey and salted by the
-   * derivationOptionsJson string, using the ApiDerivationOptions
+   * recipeJson string, using the ApiRecipe
    * specified by that string. Implements guards to ensure that the
-   * keyDerivationOptionsJson allow the client application with the
+   * recipe allowsthe client application with the
    * requester's package name to perform operations with this key.
    */
   internal suspend fun getSeedOrThrowIfClientNotAuthorized(
-    derivationOptionsJson: String?,
+    recipeJson: String?,
     type: DerivationOptions.Type,
     command: String
   ): String {
-    val derivationOptions = ApiDerivationOptions(derivationOptionsJson, type)
-    if (command == ApiStrings.Commands.getSealingKey  &&  (derivationOptionsJson == null || derivationOptionsJson.isEmpty())) {
+    val derivationOptions = ApiRecipe(recipeJson, type)
+    if (command == ApiStrings.Commands.getSealingKey  &&  (recipeJson == null || recipeJson.isEmpty())) {
       // No permission check is needed in this special case for global sealing/unsealing keys,
       // for which there's no derivationOptionSpecified, indicating a request for any _public_ unsealing key
       // which the user may choose.
@@ -106,13 +106,13 @@ open class PermissionCheckedSeedAccessor(
 
   /**
    * Used to guard calls to the unseal operation of SymmetricKey and PrivateKey,
-   * which not only needs to authorize via derivationOptionsJson, but
+   * which not only needs to authorize via recipeJson, but
    * also the postDecryptionOptions in PackagedSealedMessage
    *
    * Requests a seed generated from the user's DiceKey and salted by the
-   * derivationOptionsJson string, using the ApiDerivationOptions
+   * recipeJson string, using the ApiRecipe
    * specified by that string. Implements guards to ensure that the
-   * keyDerivationOptionsJson allow the client application with the
+   * recipe allowsthe client application with the
    * requester's package name to perform operations with this key.
    */
   internal suspend fun getSeedOrThrowIfClientNotAuthorizedToUnseal(
@@ -130,21 +130,21 @@ open class PermissionCheckedSeedAccessor(
 
   /**
    * Requests a seed generated from the user's DiceKey and salted by the
-   * derivationOptionsJson string, using the ApiDerivationOptions
+   * recipeJson string, using the ApiRecipe
    * specified by that string. Implements guards to ensure that the
-   * keyDerivationOptionsJson allow the client application with the
+   * recipe allowsthe client application with the
    * requester's package name to perform operations with this key.
    *
    * This is used to guard calls to APIs calls used to return raw non-public
    * keys: PrivateKey, SigningKey, or SymmetricKey. The specification only
    * allows the DiceKeys app to return these keys to the requesting app
-   * if the derivationOptionsJson has `"clientMayRetrieveKey": true`.
+   * if the recipeJson has `"clientMayRetrieveKey": true`.
    */
   internal suspend fun getSeedOrThrowIfClientsMayNotRetrieveKeysOrThisClientNotAuthorized(
-    derivationOptionsJson: String?,
+    recipeJson: String?,
     type: DerivationOptions.Type
   ) : String =
-    ApiDerivationOptions(derivationOptionsJson, type).let { derivationOptions ->
+    ApiRecipe(recipeJson, type).let { derivationOptions ->
       if (derivationOptions.clientMayRetrieveKey != true) {
         throw ClientMayNotRetrieveKeyException(type.name)
       }


### PR DESCRIPTION
API needed to be updated since we renamed `derivationOptionsJson` to `recipe`

Internal variables also renamed for consistency across procjects.