### PR TITLE
Support device credentials as an encryption method

### DIFF
--- a/app/src/main/java/org/dicekeys/app/encryption/AppKeystore.kt
+++ b/app/src/main/java/org/dicekeys/app/encryption/AppKeystore.kt
@@ -111,13 +111,15 @@ class AppKeystore {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                     builder.setUnlockedDeviceRequired(true)
                 }
-            }
-            KeystoreType.KEYSTORE -> {
+
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                     builder.setUserAuthenticationParameters(0, KeyProperties.AUTH_BIOMETRIC_STRONG)
                 } else {
                     builder.setUserAuthenticationValidityDurationSeconds(-1)
                 }
+            }
+            KeystoreType.KEYSTORE -> {
+               // No need to init anything
             }
         }
 

--- a/app/src/main/java/org/dicekeys/app/encryption/EncryptedDiceKey.kt
+++ b/app/src/main/java/org/dicekeys/app/encryption/EncryptedDiceKey.kt
@@ -16,13 +16,16 @@ import org.dicekeys.dicekey.Face
  */
 
 @Serializable
-data class EncryptedDiceKey(
+data class EncryptedDiceKey constructor(
         @SerialName("key_id")
         val keyId: String,
         @SerialName("center_face")
         val centerFace: String,
         @SerialName("encrypted_data")
         val encryptedData: EncryptedData,
+        // Set Biometric for backward compatibility by default
+        @SerialName("keystore_type")
+        val keystoreType: AppKeystore.KeystoreType = AppKeystore.KeystoreType.BIOMETRIC,
 ) {
 
     val centerFaceAsFace: Face by lazy {

--- a/app/src/main/java/org/dicekeys/app/encryption/EncryptedStorage.kt
+++ b/app/src/main/java/org/dicekeys/app/encryption/EncryptedStorage.kt
@@ -17,7 +17,7 @@ import org.dicekeys.dicekey.DiceKey
  */
 
 class EncryptedStorage(private val sharedPreferences: SharedPreferences) {
-    private val diceKeysLiveData : MutableLiveData<List<EncryptedDiceKey>> = MutableLiveData(listOf())
+    private val diceKeysLiveData: MutableLiveData<List<EncryptedDiceKey>> = MutableLiveData(listOf())
 
     private val sharedPreferencesListener = SharedPreferences.OnSharedPreferenceChangeListener { _, _ ->
         updateDiceKeys()
@@ -28,10 +28,10 @@ class EncryptedStorage(private val sharedPreferences: SharedPreferences) {
         sharedPreferences.registerOnSharedPreferenceChangeListener(sharedPreferencesListener)
     }
 
-    private fun updateDiceKeys(){
+    private fun updateDiceKeys() {
         GlobalScope.launch {
             val list = mutableListOf<EncryptedDiceKey>()
-            for(key in sharedPreferences.all.keys){
+            for (key in sharedPreferences.all.keys) {
                 getEncryptedData(key)?.let {
                     list += it
                 }
@@ -42,9 +42,12 @@ class EncryptedStorage(private val sharedPreferences: SharedPreferences) {
 
     fun getDiceKeysLiveData(): LiveData<List<EncryptedDiceKey>> = diceKeysLiveData
 
-    fun save(diceKey: DiceKey<*>, encryptedData: EncryptedData){
-        // TODO add center face
-        val encryptedDiceKey = EncryptedDiceKey(keyId = diceKey.keyId, centerFace = diceKey.centerFace().toHumanReadableForm(true), encryptedData = encryptedData)
+    fun save(diceKey: DiceKey<*>, encryptedData: EncryptedData, keystoreType: AppKeystore.KeystoreType) {
+        val encryptedDiceKey = EncryptedDiceKey(keyId = diceKey.keyId,
+                centerFace = diceKey.centerFace().toHumanReadableForm(true),
+                encryptedData = encryptedData,
+                keystoreType = keystoreType
+        )
 
         sharedPreferences
                 .edit()
@@ -52,15 +55,15 @@ class EncryptedStorage(private val sharedPreferences: SharedPreferences) {
                 .apply()
     }
 
-    fun remove(encryptedDiceKey: EncryptedDiceKey){
+    fun remove(encryptedDiceKey: EncryptedDiceKey) {
         remove(encryptedDiceKey.keyId)
     }
 
-    fun remove(diceKey: DiceKey<*>){
+    fun remove(diceKey: DiceKey<*>) {
         remove(diceKey.keyId)
     }
 
-    private fun remove(id: String){
+    private fun remove(id: String) {
         sharedPreferences.edit().remove(id).apply()
     }
 
@@ -68,7 +71,7 @@ class EncryptedStorage(private val sharedPreferences: SharedPreferences) {
 
 
     fun getEncryptedData(id: String): EncryptedDiceKey? {
-        return sharedPreferences.getString(id, null)?.let{
+        return sharedPreferences.getString(id, null)?.let {
             return Json.decodeFromString(it)
         }
     }

--- a/app/src/main/java/org/dicekeys/app/fragments/dicekey/DiceKeyFragment.kt
+++ b/app/src/main/java/org/dicekeys/app/fragments/dicekey/DiceKeyFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import dagger.hilt.android.AndroidEntryPoint
 import org.dicekeys.app.R
 import org.dicekeys.app.databinding.DicekeyFragmentBinding
+import org.dicekeys.app.encryption.AppKeystore
 import org.dicekeys.app.encryption.BiometricsHelper
 import javax.inject.Inject
 
@@ -21,8 +22,12 @@ class DiceKeyFragment: AbstractDiceKeyFragment<DicekeyFragmentBinding>(R.layout.
 
         binding.vm = viewModel
 
-        binding.buttonSave.setOnClickListener {
-            biometricsHelper.encrypt(viewModel.diceKey.value!!, this)
+        binding.buttonSave.setOnClickListener{
+            if(biometricsHelper.canUseBiometrics(requireContext())){
+                biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.BIOMETRIC, this)
+            }else{
+                biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.AUTHENTICATION, this)
+            }
         }
         
         binding.dicekey.setOnClickListener {

--- a/app/src/main/java/org/dicekeys/app/fragments/dicekey/SaveFragment.kt
+++ b/app/src/main/java/org/dicekeys/app/fragments/dicekey/SaveFragment.kt
@@ -22,13 +22,18 @@ class SaveFragment: AbstractDiceKeyFragment<SaveFragmentBinding>(R.layout.save_f
 
         binding.vm = viewModel
 
-        binding.buttonSaveBiometrics.setOnClickListener{
-            biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.BIOMETRIC, this)
+        binding.buttonSave.setOnClickListener {
+            when(binding.keystoreType.checkedRadioButtonId){
+                R.id.unlock_biometrics -> {
+                    biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.BIOMETRIC, this)
+                }
+                R.id.unlock_screen_lock -> {
+                    biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.AUTHENTICATION, this)
+                }
+            }
         }
 
-        binding.buttonSaveScreenLock.setOnClickListener {
-            biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.AUTHENTICATION, this)
-        }
+        binding.keystoreType.check(if(biometricsHelper.canUseBiometrics(requireContext())) R.id.unlock_biometrics else  R.id.unlock_screen_lock )
 
         binding.buttonRemove.setOnClickListener{
             viewModel.remove()
@@ -38,6 +43,11 @@ class SaveFragment: AbstractDiceKeyFragment<SaveFragmentBinding>(R.layout.save_f
     override fun onResume() {
         super.onResume()
 
-        binding.canUseBiometrics = biometricsHelper.canUseBiometrics(requireContext())
+        binding.canUseBiometrics = biometricsHelper.canUseBiometrics(requireContext()).also { canUseBiometrics ->
+            // Change selection if the checked selection is not longer available
+            if(!canUseBiometrics && binding.keystoreType.checkedRadioButtonId == R.id.unlock_biometrics){
+                binding.keystoreType.check(R.id.unlock_screen_lock)
+            }
+        }
     }
 }

--- a/app/src/main/java/org/dicekeys/app/fragments/dicekey/SaveFragment.kt
+++ b/app/src/main/java/org/dicekeys/app/fragments/dicekey/SaveFragment.kt
@@ -22,17 +22,22 @@ class SaveFragment: AbstractDiceKeyFragment<SaveFragmentBinding>(R.layout.save_f
 
         binding.vm = viewModel
 
-        binding.buttonSave.setOnClickListener{
-            if(biometricsHelper.canUseBiometrics(requireContext())){
-                biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.BIOMETRIC, this)
-            }else{
-                biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.AUTHENTICATION, this)
-            }
+        binding.buttonSaveBiometrics.setOnClickListener{
+            biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.BIOMETRIC, this)
+        }
+
+        binding.buttonSaveScreenLock.setOnClickListener {
+            biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.AUTHENTICATION, this)
         }
 
         binding.buttonRemove.setOnClickListener{
             viewModel.remove()
         }
+    }
 
+    override fun onResume() {
+        super.onResume()
+
+        binding.canUseBiometrics = biometricsHelper.canUseBiometrics(requireContext())
     }
 }

--- a/app/src/main/java/org/dicekeys/app/fragments/dicekey/SaveFragment.kt
+++ b/app/src/main/java/org/dicekeys/app/fragments/dicekey/SaveFragment.kt
@@ -3,9 +3,9 @@ package org.dicekeys.app.fragments.dicekey
 import android.os.Bundle
 import android.view.View
 import dagger.hilt.android.AndroidEntryPoint
-import org.dicekeys.app.AppFragment
 import org.dicekeys.app.R
 import org.dicekeys.app.databinding.SaveFragmentBinding
+import org.dicekeys.app.encryption.AppKeystore
 import org.dicekeys.app.encryption.BiometricsHelper
 import javax.inject.Inject
 
@@ -23,7 +23,11 @@ class SaveFragment: AbstractDiceKeyFragment<SaveFragmentBinding>(R.layout.save_f
         binding.vm = viewModel
 
         binding.buttonSave.setOnClickListener{
-            biometricsHelper.encrypt(viewModel.diceKey.value!!, this)
+            if(biometricsHelper.canUseBiometrics(requireContext())){
+                biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.BIOMETRIC, this)
+            }else{
+                biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.AUTHENTICATION, this)
+            }
         }
 
         binding.buttonRemove.setOnClickListener{

--- a/app/src/main/res/layout/dicekey_fragment.xml
+++ b/app/src/main/res/layout/dicekey_fragment.xml
@@ -98,7 +98,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="4dp"
-                    android:text="@string/save_dice_encryption_notice"
+                    android:text="@string/how_to_unlock"
                     android:textAppearance="?attr/textAppearanceBody2"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/save_fragment.xml
+++ b/app/src/main/res/layout/save_fragment.xml
@@ -81,36 +81,49 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
-                    android:text="@string/save_dice_encryption_notice"
+                    android:text="@string/how_to_unlock"
                     android:textAppearance="?attr/textAppearanceBody1"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/textView2" />
 
-                <Button
-                    android:id="@+id/buttonSaveBiometrics"
-                    isVisible="@{!vm.isSaved()}"
+                <RadioGroup
+                    android:id="@+id/keystore_type"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
-                    android:text="@string/save_biometrics"
-                    android:textAllCaps="false"
-                    android:enabled="@{canUseBiometrics}"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/textView3" />
+                    android:layout_marginTop="8dp"
+                    isVisible="@{!vm.isSaved()}"
+                    android:checkedButton="@+id/radio_button_1"
+                    app:layout_constraintTop_toBottomOf="@+id/textView3"
+                    tools:layout_editor_absoluteX="16dp">
+
+                    <RadioButton
+                        android:id="@+id/unlock_screen_lock"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:text="@string/unlock_with_lock_screen" />
+
+                    <RadioButton
+                        android:id="@+id/unlock_biometrics"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:enabled="@{canUseBiometrics}"
+                        android:text="@string/unlock_with_biometrics" />
+
+                </RadioGroup>
 
                 <Button
-                    android:id="@+id/buttonSaveScreenLock"
+                    android:id="@+id/buttonSave"
                     isVisible="@{!vm.isSaved()}"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
+                    android:text="@string/save"
                     android:textAllCaps="false"
-                    android:text="@string/save_screen_lock"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/buttonSaveBiometrics" />
+                    app:layout_constraintTop_toBottomOf="@+id/keystore_type" />
+
 
                 <Button
                     android:id="@+id/buttonRemove"
@@ -121,6 +134,7 @@
                     android:layout_marginTop="16dp"
                     android:text="@string/forget"
                     android:textAllCaps="false"
+                    tools:visibility="gone"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/textView3" />

--- a/app/src/main/res/layout/save_fragment.xml
+++ b/app/src/main/res/layout/save_fragment.xml
@@ -9,6 +9,10 @@
             name="vm"
             type="org.dicekeys.app.viewmodels.DiceKeyViewModel" />
 
+        <variable
+            name="canUseBiometrics"
+            type="boolean" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -84,15 +88,29 @@
                     app:layout_constraintTop_toBottomOf="@+id/textView2" />
 
                 <Button
-                    android:id="@+id/buttonSave"
+                    android:id="@+id/buttonSaveBiometrics"
+                    isVisible="@{!vm.isSaved()}"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    isVisible="@{!vm.isSaved()}"
-                    android:text="@string/save_the_dicekey"
+                    android:text="@string/save_biometrics"
+                    android:textAllCaps="false"
+                    android:enabled="@{canUseBiometrics}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/textView3" />
+
+                <Button
+                    android:id="@+id/buttonSaveScreenLock"
+                    isVisible="@{!vm.isSaved()}"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:textAllCaps="false"
+                    android:text="@string/save_screen_lock"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/buttonSaveBiometrics" />
 
                 <Button
                     android:id="@+id/buttonRemove"
@@ -102,6 +120,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
                     android:text="@string/forget"
+                    android:textAllCaps="false"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/textView3" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,9 @@
     <string name="biometrics_encryption_subtitle">Use your biometrics to encrypt your DiceKey and safely store it on your device.</string>
     <string name="biometrics_decryption_subtitle">Use your biometrics to decrypt your DiceKey</string>
 
+    <string name="authenticate_encryption_subtitle">Authenticate to encrypt your DiceKey and safely store it on your device.</string>
+    <string name="authenticate_decryption_subtitle">Authenticate to decrypt your DiceKey</string>
+
     <string name="biometrics_unavailable_message">You have to enable Biometrics (Fingerprint Lock) to use this feature.</string>
 
     <string name="make_a_backup_of_your_dicekey">Make a backup of your DiceKey by copying it.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,13 +21,13 @@
     <string name="complete_the_recipe">Complete the recipe above to see the output</string>
     <string name="enter_dicekey_by_hand">Enter the DiceKey by Hand</string>
     <string name="save_the_dicekey">Save the DiceKey</string>
-    <string name="save_center_die_notice">The center die will appear in the home screen.</string>
-    <string name="save_dice_encryption_notice">The other 24 dice will be encrypted and your Biometrics will unlock them.</string>
+    <string name="save_center_die_notice">Your DiceKey will be stored encrypted and identified by the center die.</string>
+    <string name="how_to_unlock">How would you like to unlock the other 24 dice?</string>
 
     <string name="tap_to_show">tap to show dice</string>
 
-    <string name="save_biometrics">Save with Biometrics</string>
-    <string name="save_screen_lock">Save with Screen Lock</string>
+    <string name="unlock_with_lock_screen">Use my lock screen unlock options</string>
+    <string name="unlock_with_biometrics">Use only my fingerprint or other biometrics</string>
 
     <string name="custom_recipe">Custom Recipe</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
     <string name="app_name">DiceKeys</string>
     <string name="error">Error</string>
     <string name="delete">Delete</string>
-    <string name="forget">forget</string>
+    <string name="forget">Forget</string>
     <string name="your_dicekeys">Your DiceKeys</string>
 
     <string name="seed_solokey">Seed a SoloKey</string>
@@ -25,6 +25,9 @@
     <string name="save_dice_encryption_notice">The other 24 dice will be encrypted and your Biometrics will unlock them.</string>
 
     <string name="tap_to_show">tap to show dice</string>
+
+    <string name="save_biometrics">Save with Biometrics</string>
+    <string name="save_screen_lock">Save with Screen Lock</string>
 
     <string name="custom_recipe">Custom Recipe</string>
 


### PR DESCRIPTION
Support device credentials as a way to encrypt your DiceKey only if Biometrics is unavailable.

Fixes #104