### PR TITLE
Add Keystore encryption type DEVICE_CREDENTIALS

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,9 +80,9 @@ dependencies {
     /** ----------------------------------------------------------------------------------------- */
 
     /**  --- Camera ----------------------------------------------------------------------------- */
-    implementation "androidx.camera:camera-camera2:1.1.0-beta02"
-    implementation "androidx.camera:camera-view:1.1.0-beta02"
-    implementation "androidx.camera:camera-lifecycle:1.1.0-beta02"
+    implementation "androidx.camera:camera-camera2:1.1.0-beta03"
+    implementation "androidx.camera:camera-view:1.1.0-beta03"
+    implementation "androidx.camera:camera-lifecycle:1.1.0-beta03"
     implementation 'com.google.zxing:core:3.4.1'
     /** ----------------------------------------------------------------------------------------- */
 
@@ -94,10 +94,10 @@ dependencies {
     /** ----------------------------------------------------------------------------------------- */
 
     /**  --- Navigation ------------------------------------------------------------------------- */
-    implementation "androidx.navigation:navigation-fragment-ktx:2.4.1"
-    implementation "androidx.navigation:navigation-ui-ktx:2.4.1"
-    testImplementation "androidx.navigation:navigation-testing:2.4.1"
-    androidTestImplementation "androidx.navigation:navigation-testing:2.4.1"
+    implementation "androidx.navigation:navigation-fragment-ktx:2.4.2"
+    implementation "androidx.navigation:navigation-ui-ktx:2.4.2"
+    testImplementation "androidx.navigation:navigation-testing:2.4.2"
+    androidTestImplementation "androidx.navigation:navigation-testing:2.4.2"
     /** ----------------------------------------------------------------------------------------- */
 
     /**  --- Hilt Dependency Injection  --------------------------------------------------------- */

--- a/app/src/main/java/org/dicekeys/app/encryption/BiometricsHelper.kt
+++ b/app/src/main/java/org/dicekeys/app/encryption/BiometricsHelper.kt
@@ -195,10 +195,14 @@ class BiometricsHelper(private val appKeystore: AppKeystore, private val encrypt
                 it.setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
                 it.setNegativeButtonText(fragment.getString(android.R.string.cancel))
             }else{
-                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.R){
-                    it.setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && keystoreType == AppKeystore.KeystoreType.DEVICE_CREDENTIALS) {
+                    it.setAllowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL)
                 } else {
-                    it.setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_WEAK or BiometricManager.Authenticators.DEVICE_CREDENTIAL)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                        it.setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL)
+                    } else {
+                        it.setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_WEAK or BiometricManager.Authenticators.DEVICE_CREDENTIAL)
+                    }
                 }
             }
 

--- a/app/src/main/java/org/dicekeys/app/fragments/dicekey/SaveFragment.kt
+++ b/app/src/main/java/org/dicekeys/app/fragments/dicekey/SaveFragment.kt
@@ -1,5 +1,6 @@
 package org.dicekeys.app.fragments.dicekey
 
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import dagger.hilt.android.AndroidEntryPoint
@@ -20,16 +21,22 @@ class SaveFragment: AbstractDiceKeyFragment<SaveFragmentBinding>(R.layout.save_f
 
         binding.buttonSave.setOnClickListener {
             when(binding.keystoreType.checkedRadioButtonId){
-                R.id.unlock_biometrics -> {
-                    biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.BIOMETRIC, this)
-                }
                 R.id.unlock_screen_lock -> {
                     biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.AUTHENTICATION, this)
+                }
+                R.id.unlock_device_credentials -> {
+                    biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.DEVICE_CREDENTIALS, this)
+                }
+                R.id.unlock_biometrics -> {
+                    biometricsHelper.encrypt(viewModel.diceKey.value!!,  AppKeystore.KeystoreType.BIOMETRIC, this)
                 }
             }
         }
 
-        binding.keystoreType.check(if(biometricsHelper.canUseBiometrics(requireContext())) R.id.unlock_biometrics else  R.id.unlock_screen_lock )
+        // DEVICE_CREDENTIAL is unsupported prior to API 30
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            binding.unlockDeviceCredentials.isEnabled = false
+        }
 
         binding.buttonRemove.setOnClickListener{
             viewModel.remove()

--- a/app/src/main/res/layout/save_fragment.xml
+++ b/app/src/main/res/layout/save_fragment.xml
@@ -96,7 +96,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
-                    android:checkedButton="@+id/radio_button_1"
+                    android:checkedButton="@+id/unlock_screen_lock"
                     app:layout_constraintTop_toBottomOf="@+id/textView3"
                     tools:layout_editor_absoluteX="16dp">
 
@@ -107,11 +107,24 @@
                         android:text="@string/unlock_with_lock_screen" />
 
                     <RadioButton
+                        android:id="@+id/unlock_device_credentials"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:text="@string/unlock_with_device_credentials" />
+
+                    <RadioButton
                         android:id="@+id/unlock_biometrics"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:enabled="@{canUseBiometrics}"
                         android:text="@string/unlock_with_biometrics" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="@style/TextAppearance.DiceKeys.Caption"
+                        android:layout_marginStart="30dp"
+                        android:text="*Stored DiceKeys will be erased if you add new fingerprints, faceprints, or other biometrics."/>
 
                 </RadioGroup>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,7 +31,8 @@
     <string name="tap_to_show">tap to show dice</string>
 
     <string name="unlock_with_lock_screen">Use my lock screen unlock options</string>
-    <string name="unlock_with_biometrics">Use only my fingerprint or other biometrics</string>
+    <string name="unlock_with_device_credentials">Use only my PIN/Pattern/Password</string>
+    <string name="unlock_with_biometrics">Use only my fingerprint or other biometrics*</string>
 
     <string name="custom_recipe">Custom Recipe</string>
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
-    ext.kotlinx_coroutines_version = '1.5.2'
+    ext.kotlin_version = '1.6.20'
+    ext.kotlinx_coroutines_version = '1.6.1'
     ext.kotlinx_serialization_version = '1.3.1'
     ext.core_ktx_version = '1.7.0'
     ext.hilt_version = '2.41'
@@ -14,10 +14,10 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version" // https://kotlinlang.org/docs/gradle.html#dependency-on-the-standard-library
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.4.1"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.4.2"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"
     }

--- a/dicekey/src/main/java/org/dicekeys/dicekey/DiceKey.kt
+++ b/dicekey/src/main/java/org/dicekeys/dicekey/DiceKey.kt
@@ -2,9 +2,13 @@ package org.dicekeys.dicekey
 import android.util.Base64
 import org.dicekeys.crypto.seeded.Secret
 import java.security.InvalidParameterException
+import java.security.SecureRandom
+import kotlin.random.Random
 
 open class DiceKey<F: Face>(val faces: List<F>) {
   companion object {
+    private val SecureRandom by lazy { Random(SecureRandom().nextInt()) }
+
     const val NumberOfFacesInKey = 25
     val rotationIndexes = listOf<List<Byte>>(
       listOf<Byte>(
@@ -63,11 +67,10 @@ open class DiceKey<F: Face>(val faces: List<F>) {
       }
     }
 
-    // Note: not secure randomness is provided
     fun createFromRandom(): DiceKey<Face> = DiceKey(faces = (0 until 25).map { Face(
-            letter = FaceLetters.random(),
-            digit = FaceDigits.random(),
-            orientationAsLowercaseLetterTrbl = FaceRotationLetters.random()
+            letter = FaceLetters.random(SecureRandom),
+            digit = FaceDigits.random(SecureRandom),
+            orientationAsLowercaseLetterTrbl = FaceRotationLetters.random(SecureRandom)
         )
     })
 

--- a/dicekey/src/main/java/org/dicekeys/dicekey/DiceKey.kt
+++ b/dicekey/src/main/java/org/dicekeys/dicekey/DiceKey.kt
@@ -42,6 +42,12 @@ open class DiceKey<F: Face>(val faces: List<F>) {
         Face(FaceLetters[index], FaceDigits[index % 6], orientationAsLowercaseLetterTrbl = FaceRotationLetters[index % 4])
       })
 
+    // Useful for UI inspection
+    val exampleA1: DiceKey<Face>
+      get() = DiceKey(faces = (0 until 25).map { index ->
+        Face(FaceLetters[0], FaceDigits[index % 5], orientationAsLowercaseLetterTrbl = FaceRotationLetters[0])
+      })
+
     @JvmStatic
     fun fromHumanReadableForm(hrf: String): DiceKey<Face> {
       return when (hrf.length) {
@@ -57,6 +63,7 @@ open class DiceKey<F: Face>(val faces: List<F>) {
       }
     }
 
+    // Note: not secure randomness is provided
     fun createFromRandom(): DiceKey<Face> = DiceKey(faces = (0 until 25).map { Face(
             letter = FaceLetters.random(),
             digit = FaceDigits.random(),


### PR DESCRIPTION
Fix #161 

Only available from Android 30.
Uses the same security as AUTHENTICATION but asks only for PIN/Pattern/Password to decrypt.