### PR TITLE
Fix Keystore key being invalidated when device is unlocked with face biometrics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation "androidx.fragment:fragment-ktx:1.5.2"
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation "androidx.biometric:biometric-ktx:1.2.0-alpha04"
+    implementation "androidx.biometric:biometric-ktx:1.2.0-alpha05"
     implementation "androidx.preference:preference-ktx:1.2.0"
     implementation "com.google.android.material:material:1.6.1"
     implementation "androidx.preference:preference-ktx:1.2.0"

--- a/app/src/main/java/org/dicekeys/app/encryption/AppKeyStore.kt
+++ b/app/src/main/java/org/dicekeys/app/encryption/AppKeyStore.kt
@@ -58,9 +58,9 @@ class AppKeyStore {
     fun isAuthenticationRequired(keyStoreCredentialsAllowed: KeyStoreCredentialsAllowed): Boolean {
         try{
             when(keyStoreCredentialsAllowed){
-                KeyStoreCredentialsAllowed.ALLOW_ACCESS_WITHOUT_REAUTHENTICATION -> getEncryptionCipher(BASIC_KEYSTORE_ALIAS, keyStoreCredentialsAllowed)
-                KeyStoreCredentialsAllowed.ALLOW_BIOMETRIC_OR_KNOWLEDGE_BASED_AUTHENTICATION, KeyStoreCredentialsAllowed.ALLOW_ONLY_KNOWLEDGE_BASED_AUTHENTICATION -> getEncryptionCipher(AUTHENTICATION_KEYSTORE_ALIAS, keyStoreCredentialsAllowed)
-                KeyStoreCredentialsAllowed.ALLOW_ONLY_BIOMETRIC_AUTHENTICATION -> getEncryptionCipher(BIOMETRICS_KEYSTORE_ALIAS, keyStoreCredentialsAllowed)
+                KeyStoreCredentialsAllowed.ALLOW_ACCESS_WITHOUT_REAUTHENTICATION -> getEncryptionCipher(BASIC_KEYSTORE_ALIAS, keyStoreCredentialsAllowed, false)
+                KeyStoreCredentialsAllowed.ALLOW_BIOMETRIC_OR_KNOWLEDGE_BASED_AUTHENTICATION, KeyStoreCredentialsAllowed.ALLOW_ONLY_KNOWLEDGE_BASED_AUTHENTICATION -> getEncryptionCipher(AUTHENTICATION_KEYSTORE_ALIAS, keyStoreCredentialsAllowed, false)
+                KeyStoreCredentialsAllowed.ALLOW_ONLY_BIOMETRIC_AUTHENTICATION -> getEncryptionCipher(BIOMETRICS_KEYSTORE_ALIAS, keyStoreCredentialsAllowed, false)
             }
         }catch (e: UserNotAuthenticatedException){
             e.printStackTrace()
@@ -100,7 +100,8 @@ class AppKeyStore {
         } catch (e: Exception) {
             e.printStackTrace()
         }
-        return false
+        // Even if we weren't able to get the Cipher, we expect the key to be valid
+        return true
     }
 
     @Throws(Exception::class)
@@ -169,12 +170,11 @@ class AppKeyStore {
         return cipher
     }
 
-    private fun getEncryptionCipher(keystoreAlias: String, keyStoreCredentialsAllowed: KeyStoreCredentialsAllowed): Cipher {
-        if (!keyStoreKeyExists(keystoreAlias) || !isKeyStoreValid(keystoreAlias)) {
+    private fun getEncryptionCipher(keystoreAlias: String, keyStoreCredentialsAllowed: KeyStoreCredentialsAllowed, recreateKeyIfNeeded: Boolean): Cipher {
+        if ((!keyStoreKeyExists(keystoreAlias) || !isKeyStoreValid(keystoreAlias)) && recreateKeyIfNeeded) {
             deleteFromKeyStore(keystoreAlias)
             initializeKeyStoreKey(keystoreAlias, keyStoreCredentialsAllowed)
         }
-
         return getEncryptionCipher(keystoreAlias)
     }
 
@@ -189,9 +189,9 @@ class AppKeyStore {
     @Throws(Exception::class)
     fun getEncryptionCipher(keyStoreCredentialsAllowed: KeyStoreCredentialsAllowed): Cipher {
         return when(keyStoreCredentialsAllowed){
-            KeyStoreCredentialsAllowed.ALLOW_ACCESS_WITHOUT_REAUTHENTICATION -> getEncryptionCipher(BASIC_KEYSTORE_ALIAS, keyStoreCredentialsAllowed)
-            KeyStoreCredentialsAllowed.ALLOW_BIOMETRIC_OR_KNOWLEDGE_BASED_AUTHENTICATION, KeyStoreCredentialsAllowed.ALLOW_ONLY_KNOWLEDGE_BASED_AUTHENTICATION -> getEncryptionCipher(AUTHENTICATION_KEYSTORE_ALIAS, keyStoreCredentialsAllowed)
-            KeyStoreCredentialsAllowed.ALLOW_ONLY_BIOMETRIC_AUTHENTICATION -> getEncryptionCipher(BIOMETRICS_KEYSTORE_ALIAS, keyStoreCredentialsAllowed)
+            KeyStoreCredentialsAllowed.ALLOW_ACCESS_WITHOUT_REAUTHENTICATION -> getEncryptionCipher(BASIC_KEYSTORE_ALIAS, keyStoreCredentialsAllowed, true)
+            KeyStoreCredentialsAllowed.ALLOW_BIOMETRIC_OR_KNOWLEDGE_BASED_AUTHENTICATION, KeyStoreCredentialsAllowed.ALLOW_ONLY_KNOWLEDGE_BASED_AUTHENTICATION -> getEncryptionCipher(AUTHENTICATION_KEYSTORE_ALIAS, keyStoreCredentialsAllowed, true)
+            KeyStoreCredentialsAllowed.ALLOW_ONLY_BIOMETRIC_AUTHENTICATION -> getEncryptionCipher(BIOMETRICS_KEYSTORE_ALIAS, keyStoreCredentialsAllowed, true)
         }
     }
 

--- a/app/src/main/java/org/dicekeys/app/fragments/ApiRequestFragment.kt
+++ b/app/src/main/java/org/dicekeys/app/fragments/ApiRequestFragment.kt
@@ -63,9 +63,9 @@ class ApiRequestFragment : AbstractListDiceKeysFragment<ApiRequestFragmentBindin
         // Needs Decryption
         if(diceKey == null){
             encryptedStorage.getEncryptedData(diceKeyDescription.keyId)?.let {
-                biometricsHelper.decrypt(it , this) {
+                biometricsHelper.decrypt(it , this, {
                     setDiceKey(it)
-                }
+                })
             }
         }else{
             setDiceKey(diceKey)

--- a/app/src/main/java/org/dicekeys/app/fragments/ListDiceKeysFragment.kt
+++ b/app/src/main/java/org/dicekeys/app/fragments/ListDiceKeysFragment.kt
@@ -52,9 +52,9 @@ class ListDiceKeysFragment : AbstractListDiceKeysFragment<ListDicekeysFragmentBi
         // Needs Decryption
         if(diceKey == null){
             encryptedStorage.getEncryptedData(diceKeyDescription.keyId)?.let {
-                biometricsHelper.decrypt(it, this@ListDiceKeysFragment) { diceKey ->
+                biometricsHelper.decrypt(it, this@ListDiceKeysFragment, { diceKey ->
                     navigateToDiceKey(diceKey)
-                }
+                })
             }
         }else{
             navigateToDiceKey(diceKey)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,6 +175,6 @@
     <string name="authenticate_using_biometrics">Authenticate using biometrics</string>
 
     <string name="user_authentication">User Authentication</string>
-    <string name="you_have_to_authenticate_to_unlock_your_device">You have to Authenticate to unlock your device</string>
+    <string name="you_have_to_authenticate_to_unlock_your_device">You have to authenticate to unlock your device</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,4 +174,7 @@
     <string name="biometrics_authentication">Biometrics Authentication</string>
     <string name="authenticate_using_biometrics">Authenticate using biometrics</string>
 
+    <string name="user_authentication">User Authentication</string>
+    <string name="you_have_to_authenticate_to_unlock_your_device">You have to Authenticate to unlock your device</string>
+
 </resources>


### PR DESCRIPTION
Fix #205

When device was unlocked with face biometrics, the keystore keys couldn't be used and where invalidated.

Now, when the device is unlocked with face biometrics, the app first ask for user authentication with biometrics or pin/pattern/etc and then asks for fingerprint biometrics to unlock the DiceKey